### PR TITLE
Use ProjectComponent instead of relying on EmberModuleType

### DIFF
--- a/src/main/kotlin/com/emberjs/actions/EmberGenerateCodeAction.kt
+++ b/src/main/kotlin/com/emberjs/actions/EmberGenerateCodeAction.kt
@@ -3,9 +3,9 @@ package com.emberjs.actions
 import com.emberjs.cli.EmberCli
 import com.emberjs.cli.EmberCliGenerateTask
 import com.emberjs.icons.EmberIcons
-import com.emberjs.utils.getEmberModule
+import com.emberjs.utils.emberRoot
 import com.emberjs.utils.getIdeView
-import com.emberjs.utils.hasEmberModule
+import com.emberjs.utils.hasEmberRoot
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.DumbAwareAction
@@ -14,11 +14,12 @@ class EmberGenerateCodeAction() :
         DumbAwareAction("Ember.js Files", "Generates new Ember.js files via ember-cli", EmberIcons.ICON_16) {
 
     override fun actionPerformed(e: AnActionEvent) {
-        val module = e.getEmberModule() ?: return
+        val project = e.project ?: return
+        val workDir = e.emberRoot ?: return
         val view = e.getIdeView()
 
         // Prepare blueprint chooser dialog
-        val dialog = EmberGenerateCodeDialog(module.project).apply {
+        val dialog = EmberGenerateCodeDialog(project).apply {
             EmberCli.BLUEPRINTS.forEach { addBlueprint(it.key, it.value) }
             selectedTemplate = DEFAULT_BLUEPRINT
         }
@@ -32,11 +33,11 @@ class EmberGenerateCodeAction() :
         FileDocumentManager.getInstance().saveAllDocuments()
 
         // Run ember-cli as modal task
-        EmberCliGenerateTask(module, dialog.selectedTemplate, dialog.enteredName, view).queue()
+        EmberCliGenerateTask(project, workDir, dialog.selectedTemplate, dialog.enteredName, view).queue()
     }
 
     override fun update(e: AnActionEvent) {
-        e.presentation.isEnabledAndVisible = e.hasEmberModule()
+        e.presentation.isEnabledAndVisible = e.hasEmberRoot
     }
 
     companion object {

--- a/src/main/kotlin/com/emberjs/cli/EmberCliGenerateTask.kt
+++ b/src/main/kotlin/com/emberjs/cli/EmberCliGenerateTask.kt
@@ -6,20 +6,19 @@ import com.intellij.ide.IdeView
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationType
-import com.intellij.openapi.application.Result
-import com.intellij.openapi.command.WriteCommandAction
-import com.intellij.openapi.module.Module
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
-import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.newvfs.RefreshQueue
 import com.intellij.psi.PsiManager
 import kotlin.text.Regex
 
-class EmberCliGenerateTask(val module: Module, val template: String, val name: String, val view: IdeView?) :
-        Task.Modal(module.project, "Generate Ember.js ${EmberCli.BLUEPRINTS[template]} '$name'", true) {
+class EmberCliGenerateTask(project: Project, val workDir: VirtualFile, val template: String,
+                           val name: String, val view: IdeView?) :
+
+        Task.Modal(project, "Generate Ember.js ${EmberCli.BLUEPRINTS[template]} '$name'", true) {
 
     private var notification: Notification? = null
     private val files = arrayListOf<VirtualFile>()
@@ -30,10 +29,6 @@ class EmberCliGenerateTask(val module: Module, val template: String, val name: S
 
     override fun run(indicator: ProgressIndicator) {
         indicator.isIndeterminate = true
-
-        val moduleRoot = ModuleRootManager.getInstance(module)
-        val workDir = moduleRoot.contentRoots.firstOrNull() ?:
-                return setNotification("Could not determine working directory", NotificationType.ERROR)
 
         indicator.log("Preparing ember command ...")
         val cli = EmberCli("generate", template, name)

--- a/src/main/kotlin/com/emberjs/icons/EmberIconProvider.kt
+++ b/src/main/kotlin/com/emberjs/icons/EmberIconProvider.kt
@@ -1,12 +1,12 @@
 package com.emberjs.icons
 
+import com.emberjs.project.EmberProjectComponent
 import com.emberjs.resolver.EmberName
-import com.emberjs.utils.getEmberModule
 import com.emberjs.utils.guessProject
 import com.intellij.icons.AllIcons
 import com.intellij.ide.IconProvider
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.util.Iconable
+import com.intellij.openapi.vfs.VfsUtil.isAncestor
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -24,9 +24,9 @@ class EmberIconProvider : IconProvider() {
             return null
 
         val project = file.guessProject() ?: return null
-        val module = file.getEmberModule(project) ?: return null
+        val roots = EmberProjectComponent.getInstance(project)?.roots ?: return null
 
-        return ModuleRootManager.getInstance(module).contentRoots
+        return roots.filter { isAncestor(it, file, true) }
                 .map { root -> EmberName.from(root, file)?.let { getIcon(it) } }
                 .filterNotNull()
                 .firstOrNull()

--- a/src/main/kotlin/com/emberjs/index/EmberClassIndex.kt
+++ b/src/main/kotlin/com/emberjs/index/EmberClassIndex.kt
@@ -1,9 +1,9 @@
 package com.emberjs.index
 
+import com.emberjs.project.EmberProjectComponent
 import com.emberjs.resolver.EmberName
-import com.emberjs.utils.getEmberModule
 import com.emberjs.utils.guessProject
-import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VfsUtil.isAncestor
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.indexing.*
 import com.intellij.util.io.EnumeratorStringDescriptor
@@ -14,7 +14,7 @@ class EmberClassIndex() :
         DataIndexer<String, Void?, FileContent> {
 
     override fun getName() = NAME
-    override fun getVersion() = 1
+    override fun getVersion() = 2
     override fun getKeyDescriptor() = KEY_DESCRIPTIOR
     override fun dependsOnFileContent() = false
 
@@ -26,9 +26,9 @@ class EmberClassIndex() :
     override fun map(inputData: FileContent): Map<String, Void?> {
         val file = inputData.file
         val project = file.guessProject() ?: return mapOf()
-        val module = file.getEmberModule(project) ?: return mapOf()
+        val roots = EmberProjectComponent.getInstance(project)?.roots ?: return mapOf()
 
-        return ModuleRootManager.getInstance(module).contentRoots
+        return roots.filter { isAncestor(it, file, true) }
                 .map { EmberName.from(it, file) }
                 .filterNotNull()
                 .toMap({ it.displayName }, { null })

--- a/src/main/kotlin/com/emberjs/index/EmberNameIndex.kt
+++ b/src/main/kotlin/com/emberjs/index/EmberNameIndex.kt
@@ -1,15 +1,11 @@
 package com.emberjs.index
 
+import com.emberjs.project.EmberProjectComponent
 import com.emberjs.resolver.EmberName
-import com.emberjs.utils.getEmberModule
 import com.emberjs.utils.guessProject
-import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VfsUtil.isAncestor
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.util.indexing.*
-import com.intellij.util.io.IOUtil
-import com.intellij.util.io.KeyDescriptor
-import java.io.DataInput
-import java.io.DataOutput
 
 class EmberNameIndex() :
         ScalarIndexExtension<EmberName>(),
@@ -17,7 +13,7 @@ class EmberNameIndex() :
         DataIndexer<EmberName, Void?, FileContent> {
 
     override fun getName() = NAME
-    override fun getVersion() = 1
+    override fun getVersion() = 2
     override fun getKeyDescriptor() = KEY_DESCRIPTIOR
     override fun dependsOnFileContent() = false
 
@@ -29,9 +25,9 @@ class EmberNameIndex() :
     override fun map(inputData: FileContent): Map<EmberName, Void?> {
         val file = inputData.file
         val project = file.guessProject() ?: return mapOf()
-        val module = file.getEmberModule(project) ?: return mapOf()
+        val roots = EmberProjectComponent.getInstance(project)?.roots ?: return mapOf()
 
-        return ModuleRootManager.getInstance(module).contentRoots
+        return roots.filter { isAncestor(it, file, true) }
                 .map { EmberName.from(it, file) }
                 .filterNotNull()
                 .toMap({ it }, { null })

--- a/src/main/kotlin/com/emberjs/navigation/EmberGotoClassContributor.kt
+++ b/src/main/kotlin/com/emberjs/navigation/EmberGotoClassContributor.kt
@@ -3,13 +3,13 @@ package com.emberjs.navigation
 import com.emberjs.icons.EmberIconProvider
 import com.emberjs.icons.EmberIcons
 import com.emberjs.index.EmberClassIndex
+import com.emberjs.project.EmberProjectComponent
 import com.emberjs.resolver.EmberName
-import com.emberjs.utils.getEmberModule
 import com.intellij.navigation.ChooseByNameContributor
 import com.intellij.navigation.DelegatingItemPresentation
 import com.intellij.navigation.NavigationItem
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VfsUtil.isAncestor
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.GlobalSearchScope
@@ -32,12 +32,12 @@ class EmberGotoClassContributor() : ChooseByNameContributor {
     }
 
     private fun convert(file: VirtualFile, project: Project): Collection<NavigationItem> {
-        val module = file.getEmberModule(project) ?: return listOf()
         val psiFile = PsiManager.getInstance(project).findFile(file) ?: return listOf()
+        val roots = EmberProjectComponent.getInstance(project)?.roots ?: return listOf()
 
         val iconProvider = EmberIconProvider()
 
-        return ModuleRootManager.getInstance(module).contentRoots
+        return roots.filter { isAncestor(it, file, true) }
                 .map { EmberName.from(it, file) }
                 .filterNotNull()
                 .map {

--- a/src/main/kotlin/com/emberjs/navigation/EmberGotoRelatedProvider.kt
+++ b/src/main/kotlin/com/emberjs/navigation/EmberGotoRelatedProvider.kt
@@ -1,13 +1,13 @@
 package com.emberjs.navigation
 
+import com.emberjs.project.EmberProjectComponent
 import com.emberjs.resolver.EmberName
 import com.emberjs.resolver.EmberResolver
-import com.emberjs.utils.getEmberModule
 import com.intellij.navigation.GotoRelatedItem
 import com.intellij.navigation.GotoRelatedProvider
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.PlatformDataKeys
-import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiManager
 
@@ -16,12 +16,11 @@ class EmberGotoRelatedProvider : GotoRelatedProvider() {
     override fun getItems(context: DataContext): List<GotoRelatedItem> {
         val project = PlatformDataKeys.PROJECT.getData(context) ?: return listOf()
         val file = PlatformDataKeys.VIRTUAL_FILE.getData(context) ?: return listOf()
-
-        val module = file.getEmberModule(project) ?: return listOf()
+        val roots = EmberProjectComponent.getInstance(project)?.roots ?: return listOf()
 
         val psiManager = PsiManager.getInstance(project)
 
-        return ModuleRootManager.getInstance(module).contentRoots
+        return roots.filter { VfsUtil.isAncestor(it, file, true) }
                 .flatMap { root ->
                     getFiles(root, file).map {
                         EmberGotoRelatedItem.from(EmberName.from(root, it), psiManager.findFile(it))

--- a/src/main/kotlin/com/emberjs/navigation/EmberTestFinder.kt
+++ b/src/main/kotlin/com/emberjs/navigation/EmberTestFinder.kt
@@ -1,11 +1,11 @@
 package com.emberjs.navigation
 
+import com.emberjs.project.EmberProjectComponent
 import com.emberjs.resolver.EmberName
 import com.emberjs.resolver.EmberResolver
-import com.emberjs.utils.getEmberModule
 import com.emberjs.utils.guessProject
 import com.emberjs.utils.originalVirtualFile
-import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -21,11 +21,11 @@ class EmberTestFinder : TestFinder {
         val file = element.originalVirtualFile
 
         val project = file.guessProject() ?: return emptyList()
-        val module = file.getEmberModule(project) ?: return emptyList()
+        val roots = EmberProjectComponent.getInstance(project)?.roots ?: return listOf()
 
         val psiManager = PsiManager.getInstance(project)
 
-        return ModuleRootManager.getInstance(module).contentRoots
+        return roots.filter { VfsUtil.isAncestor(it, file, true) }
                 .flatMap { findTestsForClass(file, it) }
                 .map { psiManager.findFile(it) }
                 .filterNotNull()
@@ -44,11 +44,11 @@ class EmberTestFinder : TestFinder {
         val file = element.originalVirtualFile
 
         val project = file.guessProject() ?: return emptyList()
-        val module = file.getEmberModule(project) ?: return emptyList()
+        val roots = EmberProjectComponent.getInstance(project)?.roots ?: return listOf()
 
         val psiManager = PsiManager.getInstance(project)
 
-        return ModuleRootManager.getInstance(module).contentRoots
+        return roots.filter { VfsUtil.isAncestor(it, file, true) }
                 .map { findClassesForTest(file, it) }
                 .filterNotNull()
                 .map { psiManager.findFile(it) }
@@ -66,9 +66,9 @@ class EmberTestFinder : TestFinder {
         val file = element.originalVirtualFile
 
         val project = file.guessProject() ?: return false
-        val module = file.getEmberModule(project) ?: return false
+        val roots = EmberProjectComponent.getInstance(project)?.roots ?: return false
 
-        return ModuleRootManager.getInstance(module).contentRoots
+        return roots.filter { VfsUtil.isAncestor(it, file, true) }
                 .map { EmberName.from(it, file) }
                 .filterNotNull()
                 .any { it.isTest }

--- a/src/main/kotlin/com/emberjs/patterns/EmberPatterns.kt
+++ b/src/main/kotlin/com/emberjs/patterns/EmberPatterns.kt
@@ -1,12 +1,12 @@
 package com.emberjs.patterns
 
+import com.emberjs.project.EmberProjectComponent
 import com.emberjs.resolver.EmberName
-import com.emberjs.utils.emberModule
 import com.emberjs.utils.originalVirtualFile
 import com.intellij.lang.javascript.patterns.JSElementPattern
 import com.intellij.lang.javascript.patterns.JSPatterns.jsArgument
 import com.intellij.lang.javascript.psi.JSLiteralExpression
-import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.patterns.InitialPatternCondition
 import com.intellij.patterns.ObjectPattern
 import com.intellij.psi.PsiElement
@@ -32,10 +32,10 @@ object EmberPatterns {
                 if (o !is PsiElement)
                     return false
 
+                val roots = EmberProjectComponent.getInstance(o.project)?.roots ?: return false
                 val file = o.originalVirtualFile
-                val module = o.emberModule ?: return false
 
-                return ModuleRootManager.getInstance(module).contentRoots
+                return roots.filter { VfsUtil.isAncestor(it, file, true) }
                         .map { EmberName.from(it, file) }
                         .filterNotNull()
                         .any { it.type in types }

--- a/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
+++ b/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
@@ -46,13 +46,16 @@ class EmberProjectComponent(val project: Project) : AbstractProjectComponent(pro
 
     private fun setupProject(project: Project) {
         // Adjust JavaScript settings for the project
-        val configuration = JSRootConfiguration.getInstance(project)
-        configuration?.storeLanguageLevelAndUpdateCaches(JSLanguageLevel.ES6)
+        JSRootConfiguration.getInstance(project)?.apply {
+            storeLanguageLevelAndUpdateCaches(JSLanguageLevel.ES6)
+        }
 
         // Enable JSHint
-        val jsHint = JSHintConfiguration.getInstance(project)
-        val jsHintState = JSHintState.Builder(jsHint.extendedState.state).setConfigFileUsed(true).build()
-        jsHint.setExtendedState(true, jsHintState)
+        JSHintConfiguration.getInstance(project).apply {
+            setExtendedState(true, JSHintState.Builder(extendedState.state)
+                    .setConfigFileUsed(true)
+                    .build())
+        }
     }
 
     companion object {

--- a/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
+++ b/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
@@ -1,0 +1,44 @@
+package com.emberjs.project
+
+import com.emberjs.utils.visitChildrenRecursively
+import com.intellij.openapi.components.AbstractProjectComponent
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileVisitor
+
+/**
+ * This class is responsible for looking for folders with an `app/app.js` file on project load
+ * and keeping the list of those folders around for other parts of the plugin.
+ */
+class EmberProjectComponent(val project: Project) : AbstractProjectComponent(project) {
+
+    val roots = arrayListOf<VirtualFile>()
+
+    override fun projectOpened() {
+        val projectRoot = project.baseDir ?: return
+
+        projectRoot.visitChildrenRecursively(object : VirtualFileVisitor<Any>() {
+            override fun visitFile(file: VirtualFile): Boolean {
+                return when {
+                    // skip further processing if this is not a folder
+                    !file.isDirectory -> false
+
+                    // skip further processing if the folder is blacklisted
+                    file.name in IGNORED_FOLDERS -> false
+
+                    // skip further processing and add folder to `roots` list if an `app/app.js` file was found
+                    file.findFileByRelativePath("app/app.js") != null -> { roots.add(file); false }
+
+                    // traverse the tree one level deeper
+                    else -> true
+                }
+            }
+        })
+    }
+
+    companion object {
+        private val IGNORED_FOLDERS = listOf("node_modules", "bower_components", "dist", "tmp")
+
+        fun getInstance(project: Project) = project.getComponent(EmberProjectComponent::class.java)
+    }
+}

--- a/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
+++ b/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
@@ -1,6 +1,10 @@
 package com.emberjs.project
 
 import com.emberjs.utils.visitChildrenRecursively
+import com.intellij.lang.javascript.dialects.JSLanguageLevel
+import com.intellij.lang.javascript.linter.jshint.JSHintConfiguration
+import com.intellij.lang.javascript.linter.jshint.JSHintState
+import com.intellij.lang.javascript.settings.JSRootConfiguration
 import com.intellij.openapi.components.AbstractProjectComponent
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
@@ -34,6 +38,21 @@ class EmberProjectComponent(val project: Project) : AbstractProjectComponent(pro
                 }
             }
         })
+
+        if (roots.isNotEmpty()) {
+            setupProject(project)
+        }
+    }
+
+    private fun setupProject(project: Project) {
+        // Adjust JavaScript settings for the project
+        val configuration = JSRootConfiguration.getInstance(project)
+        configuration?.storeLanguageLevelAndUpdateCaches(JSLanguageLevel.ES6)
+
+        // Enable JSHint
+        val jsHint = JSHintConfiguration.getInstance(project)
+        val jsHintState = JSHintState.Builder(jsHint.extendedState.state).setConfigFileUsed(true).build()
+        jsHint.setExtendedState(true, jsHintState)
     }
 
     companion object {

--- a/src/main/kotlin/com/emberjs/project/EmberProjectStructureDetector.kt
+++ b/src/main/kotlin/com/emberjs/project/EmberProjectStructureDetector.kt
@@ -2,16 +2,10 @@ package com.emberjs.project
 
 import com.intellij.ide.util.importProject.ModuleDescriptor
 import com.intellij.ide.util.importProject.ProjectDescriptor
-import com.intellij.ide.util.projectWizard.ModuleBuilder
 import com.intellij.ide.util.projectWizard.importSources.DetectedProjectRoot
 import com.intellij.ide.util.projectWizard.importSources.DetectedSourceRoot
 import com.intellij.ide.util.projectWizard.importSources.ProjectFromSourcesBuilder
 import com.intellij.ide.util.projectWizard.importSources.ProjectStructureDetector
-import com.intellij.openapi.module.Module
-import com.intellij.openapi.roots.ModifiableRootModel
-import org.jetbrains.jps.model.java.JavaResourceRootType.RESOURCE
-import org.jetbrains.jps.model.java.JavaSourceRootType.SOURCE
-import org.jetbrains.jps.model.java.JavaSourceRootType.TEST_SOURCE
 import java.io.File
 
 /**
@@ -51,28 +45,6 @@ class EmberProjectStructureDetector : ProjectStructureDetector() {
             projectDescriptor.modules = roots.map {
                 ModuleDescriptor(it.directory, EmberModuleType.instance, emptyList())
             }
-        }
-
-        // Iterate through modules
-        projectDescriptor.modules.forEach { module ->
-            module.addConfigurationUpdater(object : ModuleBuilder.ModuleConfigurationUpdater() {
-                override fun update(module: Module, rootModel: ModifiableRootModel) {
-                    setupModule(rootModel)
-                }
-            })
-        }
-    }
-
-    private fun setupModule(rootModel: ModifiableRootModel) {
-        // Mark special folders for each module
-        rootModel.contentEntries.forEach { entry ->
-            entry.addSourceFolder("${entry.url}/app", SOURCE)
-            entry.addSourceFolder("${entry.url}/public", RESOURCE)
-            entry.addSourceFolder("${entry.url}/tests", TEST_SOURCE)
-            entry.addSourceFolder("${entry.url}/tests/unit", TEST_SOURCE)
-            entry.addSourceFolder("${entry.url}/tests/integration", TEST_SOURCE)
-            entry.addExcludeFolder("${entry.url}/dist")
-            entry.addExcludeFolder("${entry.url}/tmp")
         }
     }
 }

--- a/src/main/kotlin/com/emberjs/project/EmberProjectStructureDetector.kt
+++ b/src/main/kotlin/com/emberjs/project/EmberProjectStructureDetector.kt
@@ -7,13 +7,8 @@ import com.intellij.ide.util.projectWizard.importSources.DetectedProjectRoot
 import com.intellij.ide.util.projectWizard.importSources.DetectedSourceRoot
 import com.intellij.ide.util.projectWizard.importSources.ProjectFromSourcesBuilder
 import com.intellij.ide.util.projectWizard.importSources.ProjectStructureDetector
-import com.intellij.lang.javascript.library.JSLibraryManager
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModifiableRootModel
-import com.intellij.webcore.ScriptingFrameworkDescriptor
-import com.intellij.webcore.libraries.ScriptingLibraryModel.LibraryLevel.PROJECT
 import org.jetbrains.jps.model.java.JavaResourceRootType.RESOURCE
 import org.jetbrains.jps.model.java.JavaSourceRootType.SOURCE
 import org.jetbrains.jps.model.java.JavaSourceRootType.TEST_SOURCE
@@ -62,20 +57,9 @@ class EmberProjectStructureDetector : ProjectStructureDetector() {
         projectDescriptor.modules.forEach { module ->
             module.addConfigurationUpdater(object : ModuleBuilder.ModuleConfigurationUpdater() {
                 override fun update(module: Module, rootModel: ModifiableRootModel) {
-                    setupProject(module.project)
                     setupModule(rootModel)
                 }
             })
-        }
-    }
-
-    private fun setupProject(project: Project) {
-        // Add node_modules and bower_components as library folders
-        ApplicationManager.getApplication().invokeLater {
-            ApplicationManager.getApplication().runWriteAction {
-                createLibrary(project, "node_modules", "node_modules")
-                createLibrary(project, "bower_components")
-            }
         }
     }
 
@@ -89,21 +73,6 @@ class EmberProjectStructureDetector : ProjectStructureDetector() {
             entry.addSourceFolder("${entry.url}/tests/integration", TEST_SOURCE)
             entry.addExcludeFolder("${entry.url}/dist")
             entry.addExcludeFolder("${entry.url}/tmp")
-        }
-    }
-
-    private fun createLibrary(project: Project, name: String, framework: String? = null) {
-        val folder = project.baseDir.findChild(name) ?: return
-
-        JSLibraryManager.getInstance(project).apply {
-            createLibrary(name, arrayOf(folder), arrayOf(), arrayOf(), PROJECT, true).apply {
-                if (framework != null) {
-                    frameworkDescriptor = ScriptingFrameworkDescriptor(framework, null)
-                }
-            }
-
-            libraryMappings.associateWithProject(name)
-            commitChanges()
         }
     }
 }

--- a/src/main/kotlin/com/emberjs/project/EmberProjectStructureDetector.kt
+++ b/src/main/kotlin/com/emberjs/project/EmberProjectStructureDetector.kt
@@ -7,11 +7,7 @@ import com.intellij.ide.util.projectWizard.importSources.DetectedProjectRoot
 import com.intellij.ide.util.projectWizard.importSources.DetectedSourceRoot
 import com.intellij.ide.util.projectWizard.importSources.ProjectFromSourcesBuilder
 import com.intellij.ide.util.projectWizard.importSources.ProjectStructureDetector
-import com.intellij.lang.javascript.dialects.JSLanguageLevel
 import com.intellij.lang.javascript.library.JSLibraryManager
-import com.intellij.lang.javascript.linter.jshint.JSHintConfiguration
-import com.intellij.lang.javascript.linter.jshint.JSHintState
-import com.intellij.lang.javascript.settings.JSRootConfiguration
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
@@ -74,15 +70,6 @@ class EmberProjectStructureDetector : ProjectStructureDetector() {
     }
 
     private fun setupProject(project: Project) {
-        // Adjust JavaScript settings for the project
-        val configuration = JSRootConfiguration.getInstance(project)
-        configuration?.storeLanguageLevelAndUpdateCaches(JSLanguageLevel.ES6)
-
-        // Enable JSHint
-        val jsHint = JSHintConfiguration.getInstance(project)
-        val jsHintState = JSHintState.Builder(jsHint.extendedState.state).setConfigFileUsed(true).build()
-        jsHint.setExtendedState(true, jsHintState)
-
         // Add node_modules and bower_components as library folders
         ApplicationManager.getApplication().invokeLater {
             ApplicationManager.getApplication().runWriteAction {

--- a/src/main/kotlin/com/emberjs/psi/EmberJSLiteralReference.kt
+++ b/src/main/kotlin/com/emberjs/psi/EmberJSLiteralReference.kt
@@ -3,13 +3,12 @@ package com.emberjs.psi
 import com.emberjs.icons.EmberIconProvider
 import com.emberjs.icons.EmberIcons
 import com.emberjs.index.EmberNameIndex
+import com.emberjs.project.EmberProjectComponent
 import com.emberjs.resolver.EmberName
 import com.emberjs.resolver.EmberResolver
-import com.emberjs.utils.emberModule
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
 import com.intellij.lang.javascript.psi.JSLiteralExpression
-import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementResolveResult.createResults
 import com.intellij.psi.PsiManager
@@ -33,20 +32,19 @@ class EmberJSLiteralReference(element: JSLiteralExpression, val types: Iterable<
     }
 
     private fun resolve(value: String): Collection<PsiElement> {
-        val module = element.emberModule ?: return listOf()
+        val rootsSeq = EmberProjectComponent.getInstance(project)?.roots?.asSequence() ?: return listOf()
 
         val psiManager = PsiManager.getInstance(project)
-        val contentRoots = ModuleRootManager.getInstance(module).contentRoots.asSequence()
 
         // Iterate over types that we are looking for (e.g. "model" and "adapter")
         return types.asSequence()
 
-                // Additionally iterate over content roots of the Ember.js module
+                // Additionally iterate over Ember.js roots of the project
                 .flatMap { type ->
-                    contentRoots.flatMap {
+                    rootsSeq.flatMap {
                         val resolver = EmberResolver(it)
 
-                        // Look for type with matching name in module content root
+                        // Look for type with matching name in root folder
                         sequenceOf(value, value.removeSuffix("s"))
                                 .map { resolver.resolve("$type:$it") }
                                 .distinct()

--- a/src/main/kotlin/com/emberjs/utils/AnActionEventExtensions.kt
+++ b/src/main/kotlin/com/emberjs/utils/AnActionEventExtensions.kt
@@ -1,18 +1,26 @@
 package com.emberjs.utils
 
-import com.emberjs.project.EmberModuleType
+import com.emberjs.project.EmberProjectComponent
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.LangDataKeys
-import com.intellij.openapi.module.ModuleType
+import com.intellij.openapi.vfs.VfsUtil.isAncestor
+import com.intellij.openapi.vfs.VirtualFile
 
 
-fun AnActionEvent.getEmberModule() =
-        getData(LangDataKeys.MODULE)?.let {
-            if (ModuleType.get(it) is EmberModuleType) it else null
-        }
+val AnActionEvent.virtualFile: VirtualFile?
+    get() = getData(LangDataKeys.VIRTUAL_FILE)
 
-fun AnActionEvent.hasEmberModule() =
-        getEmberModule() != null
+val AnActionEvent.emberRoot: VirtualFile?
+    get() {
+        val project = project ?: return null
+        val file = virtualFile ?: return null
+        val roots = EmberProjectComponent.getInstance(project)?.roots ?: return null
+
+        return roots.filter { isAncestor(it, file, true) }.firstOrNull()
+    }
+
+val AnActionEvent.hasEmberRoot: Boolean
+    get() = emberRoot != null
 
 fun AnActionEvent.getIdeView() =
         getData(LangDataKeys.IDE_VIEW)

--- a/src/main/kotlin/com/emberjs/utils/VirtualFileExtensions.kt
+++ b/src/main/kotlin/com/emberjs/utils/VirtualFileExtensions.kt
@@ -5,7 +5,9 @@ import com.intellij.openapi.module.ModuleType
 import com.intellij.openapi.module.ModuleUtilCore.findModuleForFile
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectLocator
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileVisitor
 
 val VirtualFile.parents: Iterable<VirtualFile>
     get() = object : Iterable<VirtualFile> {
@@ -28,3 +30,6 @@ fun VirtualFile.getModule(project: Project) = findModuleForFile(this, project)
 
 fun VirtualFile.getEmberModule(project: Project) =
         getModule(project)?.let { if (ModuleType.get(it) is EmberModuleType) it else null }
+
+fun VirtualFile.visitChildrenRecursively(visitor: VirtualFileVisitor<Any>) =
+        VfsUtil.visitChildrenRecursively(this, visitor)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -34,6 +34,13 @@
     <depends>JavaScript</depends>
     <depends optional="true">com.dmarcotte.handlebars</depends>
 
+    <project-components>
+        <component>
+            <implementation-class>com.emberjs.project.EmberProjectComponent</implementation-class>
+            <skipForDefaultProject/>
+        </component>
+    </project-components>
+
     <extensions defaultExtensionNs="com.intellij">
         <moduleType id="EMBER_MODULE" implementationClass="com.emberjs.project.EmberModuleType"/>
         <moduleBuilder builderClass="com.emberjs.project.EmberModuleBuilder"/>


### PR DESCRIPTION
The `ProjectStructureDetector` class is not used on any IDE other than IntelliJ, so we can not rely on using the `EmberModuleType` class anywhere, because WebStorm, PyCharm, etc. aren't using it. This PR changes the code to use a `ProjectComponent` instead that caches the Ember.js projects that were found during startup.

Hopefully resolves #4 