### PR TITLE
Basic Ember.js addon support

### DIFF
--- a/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
+++ b/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
@@ -43,7 +43,7 @@ class EmberProjectComponent(val project: Project) : AbstractProjectComponent(pro
                     file.name in IGNORED_FOLDERS -> false
 
                     // skip further processing and add folder to `roots` list if an `app/app.js` file was found
-                    file.findFileByRelativePath("app/app.js") != null -> { roots.add(file); false }
+                    file.isEmberFolder -> { roots.add(file); false }
 
                     // traverse the tree one level deeper
                     else -> true
@@ -131,6 +131,9 @@ class EmberProjectComponent(val project: Project) : AbstractProjectComponent(pro
         entry.addExcludeFolder("$rootUrl/dist")
         entry.addExcludeFolder("$rootUrl/tmp")
     }
+
+    private val VirtualFile.isEmberFolder: Boolean
+        get() = findFileByRelativePath("app/app.js") != null
 
     companion object {
         private val IGNORED_FOLDERS = listOf("node_modules", "bower_components", "dist", "tmp")

--- a/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
+++ b/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
@@ -124,6 +124,7 @@ class EmberProjectComponent(val project: Project) : AbstractProjectComponent(pro
     private fun setupModule(entry: ContentEntry, rootUrl: String) {
         // Mark special folders for each module
         entry.addSourceFolder("$rootUrl/app", SOURCE)
+        entry.addSourceFolder("$rootUrl/addon", SOURCE)
         entry.addSourceFolder("$rootUrl/public", RESOURCE)
         entry.addSourceFolder("$rootUrl/tests", TEST_SOURCE)
         entry.addSourceFolder("$rootUrl/tests/unit", TEST_SOURCE)

--- a/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
+++ b/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
@@ -133,7 +133,8 @@ class EmberProjectComponent(val project: Project) : AbstractProjectComponent(pro
     }
 
     private val VirtualFile.isEmberFolder: Boolean
-        get() = findFileByRelativePath("app/app.js") != null
+        get() = findFileByRelativePath("app/app.js") != null ||
+                findFileByRelativePath(".ember-cli") != null
 
     companion object {
         private val IGNORED_FOLDERS = listOf("node_modules", "bower_components", "dist", "tmp")

--- a/src/main/kotlin/com/emberjs/project/EmberProjectStructureDetector.kt
+++ b/src/main/kotlin/com/emberjs/project/EmberProjectStructureDetector.kt
@@ -16,7 +16,7 @@ class EmberProjectStructureDetector : ProjectStructureDetector() {
     override fun detectRoots(dir: File, children: Array<File>, base: File, result: MutableList<DetectedProjectRoot>):
             DirectoryProcessingResult {
 
-        if (!hasAppJs(children))
+        if (!hasAppJs(children) && !children.any { it.name == ".ember-cli" })
             return DirectoryProcessingResult.PROCESS_CHILDREN
 
         result.add(object : DetectedSourceRoot(dir, null) {


### PR DESCRIPTION
This PR adds basic support for Ember.js addons in IntelliJ. Previously Ember.js projects needed to contain an `app/app.js` file, with these changes an `.ember-cli` file is also considered for project detection.

Additionally the `addon` folder will now be marked as a source folder automatically.

This PR resolves parts of #17 