### PR TITLE
AppVeyor: Disable IntelliJ sources download

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
 version: "{branch} {build}"
 
+environment:
+  global:
+    ORG_GRADLE_PROJECT_INTELLIJ_DOWNLOAD_SOURCES: false
+
 install:
   - git submodule update --init --recursive
 


### PR DESCRIPTION
This should slightly decrease the AppVeyor build times, although the download times are still causing a majority of the delay...