### PR TITLE
Add support for in-repo addons

### DIFF
--- a/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
+++ b/src/main/kotlin/com/emberjs/project/EmberProjectComponent.kt
@@ -55,6 +55,11 @@ class EmberProjectComponent(val project: Project) : AbstractProjectComponent(pro
             }
         })
 
+        // assume the location of in-repo addons; it would be better to parse package.json
+        projectRoot.findChild("lib")?.children.orEmpty()
+                .filter { it.isInRepoAddon }
+                .forEach { roots.add(it) }
+
         if (roots.isNotEmpty()) {
             // Adjust JavaScript settings for the project
             setES6LanguageLevel(project)
@@ -164,6 +169,11 @@ class EmberProjectComponent(val project: Project) : AbstractProjectComponent(pro
     private val VirtualFile.isEmberFolder: Boolean
         get() = findFileByRelativePath("app/app.js") != null ||
                 findFileByRelativePath(".ember-cli") != null
+
+    private val VirtualFile.isInRepoAddon: Boolean
+        get() = isDirectory &&
+                findFileByRelativePath("package.json") != null &&
+                findFileByRelativePath("index.js") != null
 
     companion object {
         private val IGNORED_FOLDERS = listOf("node_modules", "bower_components", "dist", "tmp")


### PR DESCRIPTION
Assumes that addons are located in `lib` directory where `ember g in-repo-addon` puts them. I didn't want to deal with parsing `package.json` for the actual paths.

I had to manually refresh the index before the search function would work for the new code (menu option: `File -> Invalidate Caches`).

Fixes #41 