### PR TITLE
Add live templates for test, pauseTest, and andThen

### DIFF
--- a/src/main/resources/com/emberjs/template/Ember.js.xml
+++ b/src/main/resources/com/emberjs/template/Ember.js.xml
@@ -28,4 +28,23 @@
             <option name="JAVA_SCRIPT" value="true" />
         </context>
     </template>
+    <template name="test" value="test('$NAME$', function(assert) {&#10;  $END$&#10;});" description="Insert test case" toReformat="false" toShortenFQNames="true">
+        <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true" />
+        <context>
+            <option name="JAVA_SCRIPT" value="false" />
+            <option name="JS_EXPRESSION" value="false" />
+            <option name="JSX_HTML" value="false" />
+            <option name="JS_STATEMENT" value="true" />
+        </context>
+    </template>
+    <template name="pt" value="return pauseTest();" description="Insert pauseTest" toReformat="false" toShortenFQNames="true">
+        <context>
+            <option name="JAVA_SCRIPT" value="true" />
+        </context>
+    </template>
+    <template name="then" value="andThen(() =&gt; {&#10;  $END$&#10;});" description="Insert andThen" toReformat="false" toShortenFQNames="true">
+        <context>
+            <option name="JAVA_SCRIPT" value="true" />
+        </context>
+    </template>
 </templateSet>


### PR DESCRIPTION
Added a few live templates that I usually set up locally:

- 'test' inserts a test case

- 'pt' inserts a `pauseTest`

- 'then' inserts an `andThen`

