### PR TITLE
Recover EmberModuleType class

### DIFF
--- a/src/main/kotlin/com/emberjs/project/EmberModuleType.kt
+++ b/src/main/kotlin/com/emberjs/project/EmberModuleType.kt
@@ -1,0 +1,30 @@
+package com.emberjs.project
+
+import com.emberjs.icons.EmberIcons
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.module.ModuleTypeManager
+import com.intellij.openapi.module.WebModuleType
+import javax.swing.Icon
+
+/**
+ * This class exists only for legacy reasons.
+ *
+ * @deprecated Use the `EmberCliFrameworkDetector` class instead!
+ */
+class EmberModuleType : WebModuleType() {
+
+    override fun getName() = NAME
+    override fun getDescription() = DESCRIPTION
+
+    override fun getNodeIcon(isOpened: Boolean): Icon = AllIcons.Nodes.Module
+    override fun getBigIcon(): Icon = EmberIcons.ICON_24
+
+    companion object {
+        val ID = "EMBER_MODULE"
+        val NAME = "Ember.js"
+        val DESCRIPTION = "Ember.js application module"
+
+        val instance: EmberModuleType
+            get() = ModuleTypeManager.getInstance().findByID(ID) as EmberModuleType
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -54,6 +54,9 @@
         <iconProvider implementation="com.emberjs.icons.EmberIconProvider" order="first"/>
 
         <defaultLiveTemplatesProvider implementation="com.emberjs.template.EmberLiveTemplatesProvider"/>
+
+        <!-- deprecated and only included for legacy reasons -->
+        <moduleType id="EMBER_MODULE" implementationClass="com.emberjs.project.EmberModuleType"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
![bildschirmfoto_2016-11-15_um_10_13_28](https://cloud.githubusercontent.com/assets/141300/20306417/69c5f1ca-ab3a-11e6-8f6a-5d3e7e43189c.png)

This should prevent warnings like above, which were caused by the removal of the `EmberModuleType` class in #100 

/cc @dwickern 