### PR TITLE
Resolve absolute imports from the ember module prefix

### DIFF
--- a/src/main/kotlin/com/emberjs/cli/EmberCliProjectConfigurator.kt
+++ b/src/main/kotlin/com/emberjs/cli/EmberCliProjectConfigurator.kt
@@ -108,7 +108,7 @@ class EmberCliProjectConfigurator : DirectoryProjectConfigurator {
             }
         }
 
-        private fun inRepoAddons(baseDir: VirtualFile): List<VirtualFile> {
+        fun inRepoAddons(baseDir: VirtualFile): List<VirtualFile> {
             // assume the location of in-repo addons; it would be better to parse package.json
             return baseDir.findChild("lib")?.children.orEmpty().filter { it.isInRepoAddon }
         }

--- a/src/main/kotlin/com/emberjs/resolver/EmberScopeProvider.kt
+++ b/src/main/kotlin/com/emberjs/resolver/EmberScopeProvider.kt
@@ -1,0 +1,78 @@
+package com.emberjs.resolver
+
+import com.emberjs.cli.EmberCliProjectConfigurator
+import com.emberjs.utils.emberRoot
+import com.intellij.lang.javascript.DialectDetector
+import com.intellij.lang.javascript.frameworks.amd.JSModuleReference
+import com.intellij.lang.javascript.frameworks.modules.JSExactFileReference
+import com.intellij.lang.javascript.psi.resolve.JSModuleReferenceContributor
+import com.intellij.openapi.util.TextRange
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFileSystemItem
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceProvider
+import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReference
+import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReferenceSet
+import java.util.regex.Pattern
+
+/**
+ * Resolves absolute imports from the ember application root, e.g.
+ * ```
+ * import FooController from 'my-app/controllers/foo'
+ * ```
+ *
+ * Navigating to `FooController` will browse to `/app/controllers/foo.js`
+ */
+class EmberAppReferenceContributor : JSModuleReferenceContributor {
+    override fun getAllReferences(unquotedRefText: String, host: PsiElement, offset: Int, provider: PsiReferenceProvider?): Array<out PsiReference> {
+        return getCommonJSModuleReferences(unquotedRefText, host, offset, provider)
+    }
+
+    override fun getCommonJSModuleReferences(unquotedRefText: String, host: PsiElement, offset: Int, provider: PsiReferenceProvider?): Array<out PsiReference> {
+        val appRoot = host.emberRoot ?: return emptyArray()
+        val appName = getAppName(appRoot) ?: return emptyArray()
+
+        val importPath = unquotedRefText.removePrefix(appName + "/")
+        if (unquotedRefText == importPath) {
+            // only match ember app imports
+            return emptyArray()
+        }
+
+        /** Search the `/app` directories of the root and each in-repo-addon */
+        val roots = listOf(appRoot)
+            .plus(EmberCliProjectConfigurator.inRepoAddons(appRoot))
+            .map { JSExactFileReference(host, TextRange.create(offset, offset + appName.length), listOf("${it.path}/app"), null) }
+
+        val refs = object : FileReferenceSet(importPath, host, offset + appName.length + 1, provider, false, true, DialectDetector.JAVASCRIPT_FILE_TYPES_ARRAY) {
+            override fun createFileReference(range: TextRange?, index: Int, text: String?): FileReference = JSModuleReference(text, index, range, this, "file.js", true)
+            override fun computeDefaultContexts(): MutableCollection<PsiFileSystemItem> {
+                return roots
+                    .flatMap { it.multiResolve(false).asIterable() }
+                    .map { it.element }
+                    .filterIsInstance(PsiFileSystemItem::class.java)
+                    .toMutableList()
+            }
+        }
+
+        return (roots + refs.allReferences).toTypedArray()
+    }
+
+    override fun isApplicable(host: PsiElement): Boolean = DialectDetector.isES6(host)
+
+    /** Detect the name of the ember application */
+    private fun getAppName(appRoot: VirtualFile): String? {
+        val env = appRoot.findFileByRelativePath("config/environment.js") ?: return null
+        return env.inputStream.use { stream ->
+            stream.reader().useLines { lines ->
+                lines.mapNotNull { line ->
+                    val matcher = ModulePrefixPattern.matcher(line)
+                    if (matcher.find()) matcher.group(1) else null
+                }.firstOrNull()
+            }
+        }
+    }
+
+    /** Captures `my-app` from the string `modulePrefix: 'my-app'` */
+    private val ModulePrefixPattern = Pattern.compile("modulePrefix:\\s*['\"](.+?)['\"]")
+}

--- a/src/main/kotlin/com/emberjs/utils/AnActionEventExtensions.kt
+++ b/src/main/kotlin/com/emberjs/utils/AnActionEventExtensions.kt
@@ -10,10 +10,7 @@ val AnActionEvent.module: Module?
     get() = getData(LangDataKeys.MODULE)
 
 val AnActionEvent.emberRoot: VirtualFile?
-    get() {
-        val module = module ?: return null
-        return ModuleRootManager.getInstance(module).contentRoots.find { it.isEmberFolder }
-    }
+    get() = module?.emberRoot
 
 val AnActionEvent.hasEmberRoot: Boolean
     get() = emberRoot != null

--- a/src/main/kotlin/com/emberjs/utils/ModuleExtensions.kt
+++ b/src/main/kotlin/com/emberjs/utils/ModuleExtensions.kt
@@ -1,0 +1,8 @@
+package com.emberjs.utils
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.vfs.VirtualFile
+
+val Module.emberRoot: VirtualFile?
+    get() = ModuleRootManager.getInstance(this).contentRoots.find { it.isEmberFolder }

--- a/src/main/kotlin/com/emberjs/utils/PsiElementExtensions.kt
+++ b/src/main/kotlin/com/emberjs/utils/PsiElementExtensions.kt
@@ -15,6 +15,9 @@ val PsiElement.originalVirtualFile: VirtualFile
 val PsiElement.module: Module?
     get() = originalVirtualFile.let { findModuleForFile(it, project) }
 
+val PsiElement.emberRoot: VirtualFile?
+    get() = module?.emberRoot
+
 val PsiElement.parents: Iterable<PsiElement>
     get() = object : Iterable<PsiElement> {
         override fun iterator(): Iterator<PsiElement> {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -56,6 +56,10 @@
         <defaultLiveTemplatesProvider implementation="com.emberjs.template.EmberLiveTemplatesProvider"/>
     </extensions>
 
+    <extensions defaultExtensionNs="JavaScript">
+        <moduleReferenceContributor implementation="com.emberjs.resolver.EmberAppReferenceContributor"/>
+    </extensions>
+
     <actions>
         <action id="GenerateEmberCode" class="com.emberjs.actions.EmberGenerateCodeAction">
             <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFromTemplate"/>


### PR DESCRIPTION
Fixes #35. In the example,
```
import AwesomeMixin from 'my-cool-project/mixins/awesome-mixin';
```
Ctrl-clicking `AwesomeMixin` or `awesome-mixin` will open `app/mixins/awesome-mixin.js`

- I naively parse `config/environment.js` to find the module prefix (`my-cool-project`). The module prefix needs to be hard-coded in there or imports will not be resolved.
- Supports in-repo addons (their `lib/my-in-repo-addon/app` directories are included in the search)
- Only supports the "classic" ember structure (no pods)