### PR TITLE
JSHint and ESLint framework detectors

### DIFF
--- a/src/main/kotlin/com/emberjs/cli/EmberCliFrameworkDetector.kt
+++ b/src/main/kotlin/com/emberjs/cli/EmberCliFrameworkDetector.kt
@@ -1,12 +1,12 @@
 package com.emberjs.cli
 
+import com.emberjs.utils.NotLibrary
 import com.intellij.framework.FrameworkType
 import com.intellij.framework.detection.DetectedFrameworkDescription
 import com.intellij.framework.detection.FileContentPattern
 import com.intellij.framework.detection.FrameworkDetectionContext
 import com.intellij.framework.detection.FrameworkDetector
 import com.intellij.ide.projectView.actions.MarkRootActionBase
-import com.intellij.lang.javascript.library.JSLibraryUtil
 import com.intellij.openapi.fileTypes.FileType
 import com.intellij.openapi.fileTypes.PlainTextFileType
 import com.intellij.openapi.module.ModuleUtilCore
@@ -16,8 +16,6 @@ import com.intellij.openapi.roots.ModuleRootManager
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.patterns.ElementPattern
-import com.intellij.patterns.PatternCondition
-import com.intellij.util.ProcessingContext
 import com.intellij.util.indexing.FileContent
 
 class EmberCliFrameworkDetector : FrameworkDetector("Ember") {
@@ -28,13 +26,6 @@ class EmberCliFrameworkDetector : FrameworkDetector("Ember") {
         return FileContentPattern.fileContent()
                 .withName(".ember-cli")
                 .with(NotLibrary)
-    }
-
-    /** Exclude files in `node_modules`, `bower_components`, etc. from framework detection */
-    private object NotLibrary : PatternCondition<FileContent>("notExcluded") {
-        override fun accepts(content: FileContent, context: ProcessingContext?): Boolean {
-            return !JSLibraryUtil.isProbableLibraryFile(content.file)
-        }
     }
 
     override fun getFrameworkType(): FrameworkType = EmberFrameworkType

--- a/src/main/kotlin/com/emberjs/cli/EmberCliProjectConfigurator.kt
+++ b/src/main/kotlin/com/emberjs/cli/EmberCliProjectConfigurator.kt
@@ -54,24 +54,11 @@ class EmberCliProjectConfigurator : DirectoryProjectConfigurator {
             // Adjust JavaScript settings for the project
             setES6LanguageLevel(project)
 
-            // Enable JSHint
-            if (root.findChild(".jshintrc") != null) {
-                enableJSHint(project)
-            }
-
             // Add node_modules and bower_components as library folders
             setupLibraries(project, root)
 
             // Mark source and exclude directories
             setupModule(entry, root)
-        }
-
-        private fun enableJSHint(project: Project) {
-            JSHintConfiguration.getInstance(project).apply {
-                setExtendedState(true, JSHintState.Builder(extendedState.state)
-                    .setConfigFileUsed(true)
-                    .build())
-            }
         }
 
         private fun setES6LanguageLevel(project: Project) {

--- a/src/main/kotlin/com/emberjs/linter/ESLintFrameworkDetector.kt
+++ b/src/main/kotlin/com/emberjs/linter/ESLintFrameworkDetector.kt
@@ -1,0 +1,76 @@
+package com.emberjs.linter
+
+import com.emberjs.utils.NotLibrary
+import com.intellij.framework.FrameworkType
+import com.intellij.framework.detection.DetectedFrameworkDescription
+import com.intellij.framework.detection.FileContentPattern
+import com.intellij.framework.detection.FrameworkDetectionContext
+import com.intellij.framework.detection.FrameworkDetector
+import com.intellij.lang.javascript.JavaScriptFileType
+import com.intellij.lang.javascript.linter.eslint.EslintConfiguration
+import com.intellij.lang.javascript.linter.eslint.EslintUtil
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModifiableModelsProvider
+import com.intellij.openapi.roots.ui.configuration.ModulesProvider
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.patterns.ElementPattern
+import com.intellij.patterns.PatternCondition
+import com.intellij.patterns.StandardPatterns
+import com.intellij.util.ProcessingContext
+import com.intellij.util.indexing.FileContent
+import icons.JavaScriptLanguageIcons
+import javax.swing.Icon
+
+object ESLintFrameworkType : FrameworkType("ESLint") {
+    override fun getIcon(): Icon = JavaScriptLanguageIcons.FileTypes.Eslint
+    override fun getPresentableName(): String = "ESLint"
+}
+
+class ESLintFrameworkDetector : FrameworkDetector("ESLint") {
+    // FIXME: only detects .eslintrc.js, because we can only specify one file type
+    override fun getFileType(): FileType = JavaScriptFileType.INSTANCE
+
+    override fun createSuitableFilePattern(): ElementPattern<FileContent> {
+        return FileContentPattern.fileContent()
+                .withName(StandardPatterns.string().startsWith(".eslintrc"))
+                .with(IsEslintConfigFile)
+                .with(NotLibrary)
+    }
+
+    private object IsEslintConfigFile : PatternCondition<FileContent>("isEslint") {
+        override fun accepts(content: FileContent, context: ProcessingContext?): Boolean {
+            return EslintUtil.isEslintConfigFile(content.file)
+        }
+    }
+
+    override fun getFrameworkType(): FrameworkType = ESLintFrameworkType
+
+    override fun detect(newFiles: MutableCollection<VirtualFile>, context: FrameworkDetectionContext): MutableList<out DetectedFrameworkDescription> {
+        if (newFiles.isNotEmpty() && !isConfigured(context.project)) {
+            return mutableListOf(ESLintFrameworkDescription(newFiles))
+        }
+        return mutableListOf()
+    }
+
+    /** Don't suggest the framework if ESLint is alredy enabled */
+    private fun isConfigured(project: Project?): Boolean {
+        return project != null && EslintConfiguration.getInstance(project).extendedState.isEnabled
+    }
+
+    private inner class ESLintFrameworkDescription(val files: Collection<VirtualFile>) : DetectedFrameworkDescription() {
+        override fun getDetector() = this@ESLintFrameworkDetector
+        override fun getRelatedFiles() = files
+        override fun getSetupText() = "Enable ESLint code quality tool"
+        override fun equals(other: Any?) = other is ESLintFrameworkDescription && this.files == other.files
+        override fun hashCode() = files.hashCode()
+
+        override fun setupFramework(modifiableModelsProvider: ModifiableModelsProvider, modulesProvider: ModulesProvider) {
+            val project = modulesProvider.modules.firstOrNull()?.project ?: return
+
+            EslintConfiguration.getInstance(project).apply {
+                setExtendedState(true, extendedState.state)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/emberjs/linter/JSHintFrameworkDetector.kt
+++ b/src/main/kotlin/com/emberjs/linter/JSHintFrameworkDetector.kt
@@ -1,0 +1,67 @@
+package com.emberjs.linter
+
+import com.emberjs.utils.NotLibrary
+import com.intellij.framework.FrameworkType
+import com.intellij.framework.detection.DetectedFrameworkDescription
+import com.intellij.framework.detection.FileContentPattern
+import com.intellij.framework.detection.FrameworkDetectionContext
+import com.intellij.framework.detection.FrameworkDetector
+import com.intellij.lang.javascript.linter.jshint.JSHintConfiguration
+import com.intellij.lang.javascript.linter.jshint.JSHintState
+import com.intellij.lang.javascript.linter.jshint.config.JSHintConfigFileType
+import com.intellij.openapi.fileTypes.FileType
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModifiableModelsProvider
+import com.intellij.openapi.roots.ui.configuration.ModulesProvider
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.patterns.ElementPattern
+import com.intellij.util.indexing.FileContent
+import icons.JavaScriptLanguageIcons
+import javax.swing.Icon
+
+object JSHintFrameworkType : FrameworkType("JSHint") {
+    override fun getIcon(): Icon = JavaScriptLanguageIcons.FileTypes.JsHint
+    override fun getPresentableName(): String = "JSHint"
+}
+
+class JSHintFrameworkDetector : FrameworkDetector("JSHint") {
+    override fun getFileType(): FileType = JSHintConfigFileType.INSTANCE
+
+    override fun createSuitableFilePattern(): ElementPattern<FileContent> {
+        return FileContentPattern.fileContent()
+                .withName(".jshintrc")
+                .with(NotLibrary)
+    }
+
+    override fun getFrameworkType(): FrameworkType = JSHintFrameworkType
+
+    override fun detect(newFiles: MutableCollection<VirtualFile>, context: FrameworkDetectionContext): MutableList<out DetectedFrameworkDescription> {
+        if (newFiles.isNotEmpty() && !isConfigured(context.project)) {
+            return mutableListOf(JSHintFrameworkDescription(newFiles))
+        }
+        return mutableListOf()
+    }
+
+    /** Don't suggest the framework if JSHint is alredy enabled */
+    private fun isConfigured(project: Project?): Boolean {
+        return project != null && JSHintConfiguration.getInstance(project).extendedState.isEnabled
+    }
+
+    private inner class JSHintFrameworkDescription(val files: Collection<VirtualFile>) : DetectedFrameworkDescription() {
+        override fun getDetector() = this@JSHintFrameworkDetector
+        override fun getRelatedFiles() = files
+        override fun getSetupText() = "Enable JSHint code quality tool"
+        override fun equals(other: Any?) = other is JSHintFrameworkDescription && this.files == other.files
+        override fun hashCode() = files.hashCode()
+
+        override fun setupFramework(modifiableModelsProvider: ModifiableModelsProvider, modulesProvider: ModulesProvider) {
+            val project = modulesProvider.modules.firstOrNull()?.project ?: return
+
+            JSHintConfiguration.getInstance(project).apply {
+                setExtendedState(true, JSHintState.Builder(extendedState.state)
+                        .setConfigFileUsed(true)
+                        .build())
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/emberjs/utils/NotLibrary.kt
+++ b/src/main/kotlin/com/emberjs/utils/NotLibrary.kt
@@ -1,0 +1,13 @@
+package com.emberjs.utils
+
+import com.intellij.lang.javascript.library.JSLibraryUtil
+import com.intellij.patterns.PatternCondition
+import com.intellij.util.ProcessingContext
+import com.intellij.util.indexing.FileContent
+
+/** Exclude files in `node_modules`, `bower_components`, etc. from framework detection */
+object NotLibrary : PatternCondition<FileContent>("notExcluded") {
+    override fun accepts(content: FileContent, context: ProcessingContext?): Boolean {
+        return !JSLibraryUtil.isProbableLibraryFile(content.file)
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -43,6 +43,7 @@
         <applicationConfigurable instance="com.emberjs.settings.EmberApplicationConfigurable"/>
         <framework.detector implementation="com.emberjs.cli.EmberCliFrameworkDetector"/>
         <framework.detector implementation="com.emberjs.linter.JSHintFrameworkDetector"/>
+        <framework.detector implementation="com.emberjs.linter.ESLintFrameworkDetector"/>
 
         <fileBasedIndex implementation="com.emberjs.index.EmberNameIndex"/>
         <gotoClassContributor implementation="com.emberjs.navigation.EmberGotoClassContributor"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -42,6 +42,7 @@
 
         <applicationConfigurable instance="com.emberjs.settings.EmberApplicationConfigurable"/>
         <framework.detector implementation="com.emberjs.cli.EmberCliFrameworkDetector"/>
+        <framework.detector implementation="com.emberjs.linter.JSHintFrameworkDetector"/>
 
         <fileBasedIndex implementation="com.emberjs.index.EmberNameIndex"/>
         <gotoClassContributor implementation="com.emberjs.navigation.EmberGotoClassContributor"/>


### PR DESCRIPTION
Like we decided some time ago, I finally got around to doing this.

Supports `.jshintrc` (ember-cli default) and `.eslintrc.js` (ember-cli-eslint default) but not all the other config types.