### PR TITLE
use dot instead of slash for nested component autocomplete

### DIFF
--- a/src/main/kotlin/com/emberjs/hbs/HbsComponentReference.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsComponentReference.kt
@@ -5,6 +5,6 @@ import com.intellij.psi.PsiElement
 
 class HbsComponentReference(element: PsiElement) : HbsModuleReference(element, "component") {
     override fun matches(module: EmberName): Boolean {
-        return super.matches(module) || (module.type == "template" && module.name == "components/$value")
+        return super.matches(module) || (module.type == "template" && module.name == "components/${value.replace('.', '/')}")
     }
 }

--- a/src/main/kotlin/com/emberjs/hbs/HbsModuleReference.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsModuleReference.kt
@@ -20,7 +20,7 @@ open class HbsModuleReference(element: PsiElement, val moduleType: String) :
     private val psiManager: PsiManager by lazy { PsiManager.getInstance(project) }
 
     open fun matches(module: EmberName) =
-            module.type == moduleType && module.name == value
+            module.type == moduleType && module.name == value.replace('.', '/')
 
     override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> {
         // Collect all components from the index

--- a/src/main/kotlin/com/emberjs/lookup/EmberLookupElementBuilder.kt
+++ b/src/main/kotlin/com/emberjs/lookup/EmberLookupElementBuilder.kt
@@ -8,7 +8,8 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder
 
 object EmberLookupElementBuilder {
     fun create(it: EmberName): LookupElement = LookupElementBuilder
-            .create(it.name.replace("/", "."))
+            .create(it.name)
+            .withLookupString(it.name.replace('/', '.'))
             .withTypeText(it.type)
             .withIcon(EmberIconProvider.getIcon(it.type) ?: EmberIcons.EMPTY_16)
             .withCaseSensitivity(true)


### PR DESCRIPTION
When the user types `{{fo`, suggest `{{foo/bar/baz}}` instead of `{{foo.bar.baz}}`

Added the dot-delimited name as an alternate lookup string, so the IDE will autocomplete components using dots and correct them to slashes.

Convert dots to slashes when searching for references, so that e.g. "Find Usages" will treat `{{foo/bar/baz}}` and `{{foo.bar.baz}}` as valid usages.

Nested components are still listed as `foo.bar.baz component-template` in the class search.

Fixes #113