### PR TITLE
Fix project configurator

### DIFF
--- a/src/main/kotlin/com/emberjs/cli/EmberCliProjectConfigurator.kt
+++ b/src/main/kotlin/com/emberjs/cli/EmberCliProjectConfigurator.kt
@@ -40,8 +40,8 @@ class EmberCliProjectConfigurator : DirectoryProjectConfigurator {
             val model = ModuleRootManager.getInstance(module).modifiableModel
             val entry = MarkRootActionBase.findContentEntry(model, baseDir)
             if (entry != null) {
-                setupEmber(project, entry, baseDir)
                 ApplicationManager.getApplication().runWriteAction {
+                    setupEmber(project, entry, baseDir)
                     model.commit()
                     project.save()
                 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -44,6 +44,8 @@
         <framework.detector implementation="com.emberjs.cli.EmberCliFrameworkDetector"/>
         <framework.detector implementation="com.emberjs.linter.JSHintFrameworkDetector"/>
         <framework.detector implementation="com.emberjs.linter.ESLintFrameworkDetector"/>
+        <directoryProjectConfigurator implementation="com.emberjs.cli.EmberCliProjectConfigurator"
+                                      order="after PlatformProjectConfigurator"/>
 
         <fileBasedIndex implementation="com.emberjs.index.EmberNameIndex"/>
         <gotoClassContributor implementation="com.emberjs.navigation.EmberGotoClassContributor"/>


### PR DESCRIPTION
It was not being registered in the plugin.xml
The project configurator is used when the ember app is in the root project directory.
This will allow opening some projects in PHPStorm #121