### PR TITLE
Annotate model relationships (fixes #130)

### DIFF
--- a/src/main/kotlin/com/emberjs/psi/EmberRelationshipAnnotator.kt
+++ b/src/main/kotlin/com/emberjs/psi/EmberRelationshipAnnotator.kt
@@ -1,0 +1,79 @@
+package com.emberjs.psi
+
+import com.emberjs.icons.EmberIconProvider
+import com.emberjs.index.EmberNameIndex
+import com.emberjs.resolver.EmberName
+import com.emberjs.utils.dasherize
+import com.intellij.codeHighlighting.Pass
+import com.intellij.codeInsight.daemon.DefaultGutterIconNavigationHandler
+import com.intellij.codeInsight.daemon.LineMarkerInfo
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.javascript.psi.JSProperty
+import com.intellij.openapi.editor.markup.GutterIconRenderer
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.search.ProjectScope
+
+class EmberRelationshipAnnotator : Annotator {
+
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        if (element !is JSProperty) return
+
+        val key = element.name ?: return
+        val identifier = element.nameIdentifier ?: return
+        val value = element.value?.text ?: return
+
+        // Extract e.g. "model:foobar" from property key and optional injection name
+        val name = extractRelationshipModel(key, value) ?: return
+        val icon = EmberIconProvider.getIcon(name.type) ?: return
+
+        // Find corresponding PsiFiles
+        val project = element.project
+        val scope = ProjectScope.getAllScope(project)
+        val psiManager = PsiManager.getInstance(project)
+
+        val referencedFiles = EmberNameIndex.getFilteredKeys(scope) { it == name }
+                .flatMap { EmberNameIndex.getContainingFiles(it, scope) }
+                .map { psiManager.findFile(it) }
+                .filterNotNull()
+
+        if (referencedFiles.isEmpty()) return
+
+        // Create an annotation with a gutter icon renderer
+        holder.createInfoAnnotation(identifier, null).apply {
+            val navHandler = DefaultGutterIconNavigationHandler<PsiElement>(referencedFiles, name.displayName)
+            val lmi = LineMarkerInfo(identifier, identifier.textRange, icon, Pass.LINE_MARKERS,
+                    null, navHandler, GutterIconRenderer.Alignment.CENTER)
+
+            gutterIconRenderer = LineMarkerInfo.LineMarkerGutterIconRenderer(lmi)
+        }
+    }
+
+    companion object {
+        val CAPTURED_STRING_VAL = """(?:'([^']*)'|"([^"]*)")"""
+
+        val BELONGS_TO = """(?:DS\.belongsTo|belongsTo)"""
+        val HAS_MANY = """(?:DS\.hasMany|hasMany)"""
+
+        val ANY_OBJECT = """\{[^}]*}"""
+        val ANY_VARIABLE = """[\w]+"""
+
+        val BELONGS_TO_RE = """$BELONGS_TO\((?:$CAPTURED_STRING_VAL\s*(?:,\s*(?:$ANY_OBJECT|$ANY_VARIABLE))?)?\)""".toRegex()
+        val HAS_MANY_RE = """$HAS_MANY\((?:$CAPTURED_STRING_VAL\s*(?:,\s*(?:$ANY_OBJECT|$ANY_VARIABLE))?)?\)""".toRegex()
+        val MODEL = "model"
+
+        fun extractRelationshipModel(key: String, value: String): EmberName? {
+            val (modelName) = BELONGS_TO_RE.matchEntire(value)?.destructured ?:
+                    HAS_MANY_RE.matchEntire(value)?.destructured ?:
+                    return null
+
+            val name = when {
+                modelName.isNotEmpty() -> modelName
+                else -> key
+            }
+
+            return EmberName(MODEL, name.dasherize())
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -49,6 +49,7 @@
         <gotoClassContributor implementation="com.emberjs.navigation.EmberGotoClassContributor"/>
         <gotoRelatedProvider implementation="com.emberjs.navigation.EmberGotoRelatedProvider"/>
         <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberInjectionAnnotator"/>
+        <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberRelationshipAnnotator"/>
 
         <testFinder implementation="com.emberjs.navigation.EmberTestFinder"/>
 

--- a/src/test/kotlin/com/emberjs/psi/EmberRelationshipAnnotatorTest.kt
+++ b/src/test/kotlin/com/emberjs/psi/EmberRelationshipAnnotatorTest.kt
@@ -1,0 +1,44 @@
+package com.emberjs.psi
+
+import com.emberjs.resolver.EmberName
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class EmberRelationshipAnnotatorTest {
+
+    @Test fun fooBelongsTo() = doTest("foo", "belongsTo()", "model:foo")
+    @Test fun belongsTo() = doTest("bar", "belongsTo('foo')", "model:foo")
+    @Test fun fooBarBelongsTo() = doTest("bar", "belongsTo('foo-bar')", "model:foo-bar")
+    @Test fun dsBelongsTo() = doTest("bar", "DS.belongsTo('foo')", "model:foo")
+
+    @Test fun variableFooBarBelongsTo() = doTest("bar", "belongsTo('foo-bar',config)", "model:foo-bar")
+    @Test fun variableDsBelongsTo() = doTest("bar", "DS.belongsTo('foo' , config)", "model:foo")
+
+    @Test fun objectBelongsTo() = doTest("bar", "belongsTo('foo', config)", "model:foo")
+    @Test fun objectFooBarBelongsTo() = doTest("bar", "belongsTo('foo-bar',config)", "model:foo-bar")
+    @Test fun objectDsBelongsTo() = doTest("bar", "DS.belongsTo('foo' , config)", "model:foo")
+
+    @Test fun barHasMany() = doTest("bar", "hasMany()", "model:bar")
+    @Test fun hasMany() = doTest("foo", "hasMany('bar')", "model:bar")
+    @Test fun barBazHasMany() = doTest("foo", "hasMany('bar-baz')", "model:bar-baz")
+    @Test fun dsHasMany() = doTest("foo", "DS.hasMany('bar')", "model:bar")
+
+    @Test fun variableHasMany() = doTest("foo", "hasMany('bar', config)", "model:bar")
+    @Test fun variableBarBazHasMany() = doTest("foo", "hasMany('bar-baz',config)", "model:bar-baz")
+    @Test fun variableDsHasMany() = doTest("foo", "DS.hasMany('bar' , config)", "model:bar")
+
+    @Test fun objectHasMany() = doTest("foo", "hasMany('bar', {})", "model:bar")
+    @Test fun objectBarBazHasMany() = doTest("foo", "hasMany('bar-baz',{})", "model:bar-baz")
+    @Test fun objectDsHasMany() = doTest("foo", "DS.hasMany('bar' , {})", "model:bar")
+
+    @Test fun emberBelongsTo() = doTest("foo", "Ember.belongsTo", null)
+    @Test fun belongsToFoo() = doTest("foo", "belongsTo.foo()", null)
+    @Test fun foo() = doTest("foo", "foo", null)
+    @Test fun noCallBelongsTo() = doTest("foo", "belongsTo", null)
+    @Test fun noCallHasMany() = doTest("foo", "hasMany", null)
+
+    private fun doTest(key: String, value: String, expected: String?) {
+        assertThat(EmberRelationshipAnnotator.extractRelationshipModel(key, value))
+                .isEqualTo(expected?.let { EmberName.from(it) })
+    }
+}


### PR DESCRIPTION
This handles each `belongsTo`/`hasMany` that is used like this:

- `hasMany()`
- `hasMany('foo')`
- `hasMany('foo', {...})`
- `hasMany('foo', anything)`

We could simplify it a bit by allowing anything after the comma instead of doing a check for something object like or a word.

It uses the default model icon:
![20170628-210631](https://user-images.githubusercontent.com/1205444/27656355-f6e0d4c0-5c48-11e7-89f3-a4dc99730cc3.png)

