### PR TITLE
add "addon-test-support" directory to reference search path

### DIFF
--- a/src/main/kotlin/com/emberjs/resolver/EmberModuleReferenceContributor.kt
+++ b/src/main/kotlin/com/emberjs/resolver/EmberModuleReferenceContributor.kt
@@ -55,7 +55,7 @@ class EmberModuleReferenceContributor : JSModuleReferenceContributor {
 
         /** Search the `/app` and `/addon` directories of the root and each in-repo-addon */
         val roots = modules
-                .flatMap { listOfNotNull(it.findChild("app"), it.findChild("addon")) }
+                .flatMap { listOfNotNull(it.findChild("app"), it.findChild("addon"), it.findChild("addon-test-support")) }
                 .map { JSExactFileReference(host, TextRange.create(offset, offset + packageName.length), listOf(it.path), null) }
 
         val refs = object : FileReferenceSet(importPath, host, offset + packageName.length + 1, provider, false, true, DialectDetector.JAVASCRIPT_FILE_TYPES_ARRAY) {


### PR DESCRIPTION
fixes navigation into [ember-native-dom-helpers](https://github.com/cibernox/ember-native-dom-helpers), for example cmd/ctrl-clicking `waitUntil` in 
```js
import { waitUntil } from 'ember-native-dom-helpers';
```