### PR TITLE
Update dependencies for IDEA 2017.3 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ buildscript {
         kotlinVersion = '1.1.2'
 
         // see https://www.jetbrains.com/intellij-repository/releases/
-        intellijVersion = '172.2656.10'
+        intellijVersion = '173.2099.14'
 
         // see https://plugins.jetbrains.com/idea/plugin/6884-handlebars-mustache
-        handlebarsPluginVersion = '172.2656.13'
+        handlebarsPluginVersion = '173.2099.6'
     }
 
     repositories {


### PR DESCRIPTION
IDEA-based IDEs have opened 2017.3 EAPs, the plugin is missing actual version.