### PR TITLE
Add support for ember test run configuration

### DIFF
--- a/doc/features.md
+++ b/doc/features.md
@@ -144,6 +144,14 @@ A new `Ember Serve` run configuration can be created through
 To configure advanced settings like the server host, proxy or ssl, expand the
 `Advanced settings` panel.
 
+### Running ember tests
+
+This plugin also adds a `Ember Test` run configuration that will run your projects tests.
+A new `Ember Test` run configuration can be created through
+`Run → Edit Configurations...`.
+
+To configure advanced settings like the server host, test filter or config file, expand the
+`Advanced settings` panel.
 
 Live Templates
 -------------------------------------------------------------------------------

--- a/src/main/kotlin/com/emberjs/configuration/BooleanOptionsField.kt
+++ b/src/main/kotlin/com/emberjs/configuration/BooleanOptionsField.kt
@@ -3,7 +3,6 @@ package com.emberjs.configuration
 import com.emberjs.configuration.utils.ElementUtils
 import org.jdom.Element
 import javax.swing.JCheckBox
-import javax.swing.JComponent
 
 class BooleanOptionsField(
         default: Boolean,
@@ -12,23 +11,17 @@ class BooleanOptionsField(
 ) : OptionsField<Boolean>(default, field, cmdlineOptionName) {
     override var value: Boolean = default
 
-    override fun writeToElement(element: Element) {
-        ElementUtils.writeBool(element, this.field, this.value)
-    }
-
-    override fun readFromElement(element: Element) {
-        this.value = ElementUtils.readBool(element, this.field) ?: this.default
-    }
-
-    override fun writeToComponent(component: JComponent) {
+    override fun writeTo(component: Any) {
         when (component) {
             is JCheckBox -> component.isSelected = value
+            is Element -> ElementUtils.writeBool(component, this.field, this.value)
         }
     }
 
-    override fun readFromComponent(component: JComponent) {
+    override fun readFrom(component: Any) {
         when (component) {
             is JCheckBox -> value = component.isSelected
+            is Element -> this.value = ElementUtils.readBool(component, this.field) ?: this.default
         }
     }
 }

--- a/src/main/kotlin/com/emberjs/configuration/EmberCommandLineState.kt
+++ b/src/main/kotlin/com/emberjs/configuration/EmberCommandLineState.kt
@@ -1,19 +1,24 @@
 package com.emberjs.configuration
 
 import com.emberjs.cli.EmberCli
+import com.emberjs.utils.emberRoot
 import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.process.KillableColoredProcessHandler
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.openapi.actionSystem.LangDataKeys
 
-class EmberCommandLineState(environment: ExecutionEnvironment) : CommandLineState(environment) {
+open class EmberCommandLineState(environment: ExecutionEnvironment) : CommandLineState(environment) {
     override fun startProcess(): ProcessHandler {
         val configuration = (environment.runProfile as EmberConfiguration)
         val argList = configuration.options.toCommandLineOptions()
 
+        val workingDirectory = environment.dataContext?.getData(LangDataKeys.MODULE)?.emberRoot?.path ?:
+                environment.project.basePath
+
         val cmd = EmberCli(environment.project, configuration.command, *argList)
-                .apply { workDirectory = environment.project.basePath }
+                .apply { workDirectory = workingDirectory }
                 .commandLine()
                 .apply {
                     // taken from intellij-rust

--- a/src/main/kotlin/com/emberjs/configuration/OptionsField.kt
+++ b/src/main/kotlin/com/emberjs/configuration/OptionsField.kt
@@ -9,9 +9,7 @@ abstract class OptionsField<T>(
         val cmdlineOptionName: String
 ) {
     abstract var value : T
-    abstract fun writeToElement(element: Element)
-    abstract fun readFromElement(element: Element)
 
-    abstract fun writeToComponent(component: JComponent)
-    abstract fun readFromComponent(component: JComponent)
+    abstract fun writeTo(component: Any)
+    abstract fun readFrom(component: Any)
 }

--- a/src/main/kotlin/com/emberjs/configuration/serve/ui/EmberServeSettingsEditor.kt
+++ b/src/main/kotlin/com/emberjs/configuration/serve/ui/EmberServeSettingsEditor.kt
@@ -59,14 +59,14 @@ class EmberServeSettingsEditor : SettingsEditor<EmberServeConfiguration>() {
 
     override fun resetEditorFrom(serveConfiguration: EmberServeConfiguration) {
         mappings.forEach { (first, second) ->
-            second.get(serveConfiguration.options).writeToComponent(first as JComponent)
+            first?.let { second.get(serveConfiguration.options).writeTo(it) }
         }
     }
 
     @Throws(ConfigurationException::class)
     override fun applyEditorTo(serveConfiguration: EmberServeConfiguration) {
         mappings.forEach { (first, second) ->
-            second.get(serveConfiguration.options).readFromComponent(first as JComponent)
+            first?.let { second.get(serveConfiguration.options).readFrom(it) }
         }
     }
 

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestCommandLineState.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestCommandLineState.kt
@@ -1,0 +1,36 @@
+package com.emberjs.configuration.test
+
+import com.emberjs.configuration.EmberCommandLineState
+import com.emberjs.configuration.EmberConfiguration
+import com.intellij.execution.DefaultExecutionResult
+import com.intellij.execution.ExecutionResult
+import com.intellij.execution.Executor
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.process.ProcessHandler
+import com.intellij.execution.runners.ExecutionEnvironment
+import com.intellij.execution.runners.ProgramRunner
+import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil
+import com.intellij.execution.testframework.autotest.ToggleAutoTestAction
+import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil.createAndAttachConsole
+
+class EmberTestCommandLineState(environment: ExecutionEnvironment) : EmberCommandLineState(environment) {
+    private val TEST_FRAMEWORK_NAME = "ember-qunit"
+
+    override fun execute(executor: Executor, runner: ProgramRunner<*>): ExecutionResult {
+        val configuration = (environment.runProfile as EmberConfiguration)
+
+        // enforce teamcity reporter because converter requires it
+        (configuration.options as EmberTestOptions).reporter.value = "teamcity"
+
+        val processHandler: ProcessHandler = startProcess()
+
+        val properties = EmberTestConsoleProperties(configuration as RunConfiguration, TEST_FRAMEWORK_NAME, executor)
+        val console = createAndAttachConsole(TEST_FRAMEWORK_NAME, processHandler, properties)
+
+        SMTestRunnerConnectionUtil.createAndAttachConsole(TEST_FRAMEWORK_NAME, processHandler, properties)
+
+        val executionResult = DefaultExecutionResult(console, processHandler, *createActions(console, processHandler))
+        executionResult.setRestartActions(ToggleAutoTestAction())
+        return executionResult
+    }
+}

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfiguration.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfiguration.kt
@@ -1,8 +1,7 @@
-package com.emberjs.configuration.serve
+package com.emberjs.configuration.test
 
-import com.emberjs.configuration.EmberCommandLineState
 import com.emberjs.configuration.EmberConfiguration
-import com.emberjs.configuration.serve.ui.EmberServeSettingsEditor
+import com.emberjs.configuration.test.ui.EmberTestSettingsEditor
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.Executor
 import com.intellij.execution.configurations.*
@@ -13,13 +12,13 @@ import org.jdom.Element
 import org.jetbrains.annotations.NotNull
 import org.jetbrains.annotations.Nullable
 
-class EmberServeConfiguration(project: Project, factory: ConfigurationFactory, name: String) : RunConfigurationBase(project, factory, name), EmberConfiguration {
-    override val options = EmberServeOptions()
-    override val command: String = "serve"
+class EmberTestConfiguration(project: Project, factory: ConfigurationFactory, name: String) : RunConfigurationBase(project, factory, name), EmberConfiguration {
+    override val options = EmberTestOptions()
+    override val command: String = "test"
 
     @NotNull
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
-        return EmberServeSettingsEditor()
+        return EmberTestSettingsEditor()
     }
 
     @Throws(RuntimeConfigurationException::class)
@@ -30,7 +29,7 @@ class EmberServeConfiguration(project: Project, factory: ConfigurationFactory, n
     @Nullable
     @Throws(ExecutionException::class)
     override fun getState(@NotNull executor: Executor, @NotNull executionEnvironment: ExecutionEnvironment): RunProfileState? {
-        return EmberCommandLineState(executionEnvironment)
+        return EmberTestCommandLineState(executionEnvironment)
     }
 
     override fun writeExternal(element: Element) {

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfigurationFactory.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfigurationFactory.kt
@@ -1,0 +1,21 @@
+package com.emberjs.configuration.test
+
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.configurations.ConfigurationType
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.openapi.project.Project
+
+class EmberTestConfigurationFactory(type: ConfigurationType) : ConfigurationFactory(type) {
+
+    override fun createTemplateConfiguration(project: Project): RunConfiguration {
+        return EmberTestConfiguration(project, this, "Ember test")
+    }
+
+    override fun getName(): String {
+        return FACTORY_NAME;
+    }
+
+    companion object {
+        private val FACTORY_NAME = "Ember test configuration factory"
+    }
+}

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfigurationType.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfigurationType.kt
@@ -1,0 +1,16 @@
+package com.emberjs.configuration.test
+
+import com.emberjs.icons.EmberIcons
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.configurations.ConfigurationTypeBase
+
+class EmberTestConfigurationType : ConfigurationTypeBase(
+        "EMBER_TEST_CONFIGURATION",
+        "Ember Test",
+        "Ember Test Configuration",
+        EmberIcons.ICON_16
+) {
+    override fun getConfigurationFactories(): Array<ConfigurationFactory> {
+        return arrayOf(EmberTestConfigurationFactory(this))
+    }
+}

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestConsoleProperties.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestConsoleProperties.kt
@@ -1,0 +1,21 @@
+package com.emberjs.configuration.test
+
+import com.intellij.execution.Executor
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.testframework.TestConsoleProperties
+import com.intellij.execution.testframework.sm.SMCustomMessagesParsing
+import com.intellij.execution.testframework.sm.runner.OutputToGeneralTestEventsConverter
+import com.intellij.execution.testframework.sm.runner.SMTRunnerConsoleProperties
+
+class EmberTestConsoleProperties(
+        configuration: RunConfiguration,
+        TEST_FRAMEWORK_NAME: String,
+        executor: Executor) : SMTRunnerConsoleProperties(
+        configuration,
+        TEST_FRAMEWORK_NAME,
+        executor
+), SMCustomMessagesParsing {
+    override fun createTestEventsConverter(testFrameworkName: String, consoleProperties: TestConsoleProperties): OutputToGeneralTestEventsConverter {
+        return EmberTestOutputToGeneralTestEventsConverter(testFrameworkName, consoleProperties);
+    }
+}

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestOptions.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestOptions.kt
@@ -1,0 +1,80 @@
+package com.emberjs.configuration.test
+
+import com.emberjs.configuration.EmberOptions
+import com.emberjs.configuration.OptionsField
+import com.emberjs.configuration.StringOptionsField
+
+enum class LaunchType(val value: String) {
+    DEFAULT("DEFAULT"),
+    CUSTOM("CUSTOM"),
+}
+
+enum class FilterType(val value: String) {
+    ALL("ALL"),
+    MODULE("MODULE"),
+    FILTER("FILTER")
+}
+
+class EmberTestOptions : EmberOptions {
+    val environment = StringOptionsField("test", "ENVIRONMENT", "environment")
+    val configFile = StringOptionsField("", "CONFIG_FILE", "config-file")
+    val host = StringOptionsField("", "HOST", "host")
+    val testPort = StringOptionsField("7357", "TEST_PORT", "test-port")
+
+    val filterOption = StringOptionsField(FilterType.ALL.value, "FILTER_OPTION", "")
+    val filter = StringOptionsField("", "FILTER", "filter")
+    val module = StringOptionsField("", "MODULE", "module")
+
+    val watcher = StringOptionsField("events", "WATCHER", "watcher")
+    val testemDebug = StringOptionsField("", "TESTEM_DEBUG", "testem-debug")
+    val testPage = StringOptionsField("", "TEST_PAGE", "test-page")
+    val path = StringOptionsField("", "PATH", "path")
+    val query = StringOptionsField("", "QUERY", "query")
+    val reporter = StringOptionsField("tap", "REPORTER", "reporter")
+
+    val launchOption = StringOptionsField(LaunchType.DEFAULT.value, "LAUNCH_OPTION", "")
+    val launch = StringOptionsField("", "LAUNCH", "launch")
+
+    override fun fields(): Array<OptionsField<out Any>> {
+        return arrayOf(
+                environment,
+                configFile,
+                host,
+                testPort,
+                filter,
+                filterOption,
+                module,
+                watcher,
+                testemDebug,
+                testPage,
+                path,
+                query,
+                reporter,
+                launch,
+                launchOption
+        )
+    }
+
+    override fun toCommandLineOptions(): Array<String> {
+        val options = fields()
+                .filter {
+                    // allow any fields that aren't LAUNCH, FILTER, MODULE
+                    !arrayOf("LAUNCH", "FILTER", "MODULE").contains(it.field) ||
+                    // allow any LAUNCH if LAUNCH_OPTION is CUSTOM
+                    it.field == "LAUNCH" && launchOption.value == LaunchType.CUSTOM.value ||
+                    // allow any FILTER if FILTER_OPTION is FILTER
+                    it.field =="FILTER" && filterOption.value == FilterType.FILTER.value ||
+                    // allow any MODULE if FILTER_OPTION is MODULE
+                    it.field =="MODULE" && filterOption.value == FilterType.MODULE.value
+                }
+                .filter { optionsField ->
+                    optionsField.cmdlineOptionName.isNotEmpty() &&
+                    optionsField.value != optionsField.default &&
+                    optionsField.value.toString().isNotEmpty()
+                }
+                .map { "--${it.cmdlineOptionName}=${it.value}" }
+                .toTypedArray()
+
+        return options
+    }
+}

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestOutputToGeneralTestEventsConverter.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestOutputToGeneralTestEventsConverter.kt
@@ -1,0 +1,23 @@
+package com.emberjs.configuration.test
+
+import com.intellij.execution.testframework.TestConsoleProperties
+import com.intellij.execution.testframework.sm.runner.OutputLineSplitter
+import com.intellij.execution.testframework.sm.runner.OutputToGeneralTestEventsConverter
+import com.intellij.openapi.util.Key
+
+class EmberTestOutputToGeneralTestEventsConverter(testFrameworkName: String, consoleProperties: TestConsoleProperties) :
+        OutputToGeneralTestEventsConverter(testFrameworkName, consoleProperties) {
+    var splitter: OutputLineSplitter
+
+    init {
+        splitter = object : OutputLineSplitter(true) {
+            override fun onLineAvailable(text: String, outputType: Key<*>, tcLikeFakeOutput: Boolean) {
+                processConsistentText(text, outputType, tcLikeFakeOutput)
+            }
+        }
+    }
+
+    override fun process(text: String, outputType: Key<*>) {
+        splitter.process(text, outputType)
+    }
+}

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestProgramRunner.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestProgramRunner.kt
@@ -1,0 +1,12 @@
+package com.emberjs.configuration.test
+
+import com.intellij.execution.configurations.RunProfile
+import com.intellij.execution.executors.DefaultRunExecutor
+import com.intellij.execution.runners.DefaultProgramRunner
+
+class EmberTestProgramRunner : DefaultProgramRunner() {
+    override fun getRunnerId(): String = "EmberTestRunner"
+
+    override fun canRun(executorId: String, profile: RunProfile): Boolean =
+            executorId == DefaultRunExecutor.EXECUTOR_ID && profile is EmberTestConfiguration
+}

--- a/src/main/kotlin/com/emberjs/configuration/test/ui/EmberTestSettingsEditor.form
+++ b/src/main/kotlin/com/emberjs/configuration/test/ui/EmberTestSettingsEditor.form
@@ -1,0 +1,344 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.emberjs.configuration.test.ui.EmberTestSettingsEditor">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+    <margin top="0" left="0" bottom="0" right="0"/>
+    <constraints>
+      <xy x="20" y="20" width="560" height="559"/>
+    </constraints>
+    <properties/>
+    <border type="none"/>
+    <children>
+      <grid id="5303a" binding="advancedSettingsWrapper" layout-manager="BorderLayout" hgap="0" vgap="0">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <grid id="35590" binding="advancedSettings" layout-manager="BorderLayout" hgap="0" vgap="0">
+            <constraints border-constraint="Center"/>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <grid id="ee16" layout-manager="GridLayoutManager" row-count="10" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="0" left="0" bottom="0" right="0"/>
+                <constraints border-constraint="Center"/>
+                <properties/>
+                <border type="none"/>
+                <children>
+                  <component id="a3b8d" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="host"/>
+                    </properties>
+                  </component>
+                  <component id="a2a" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                        <preferred-size width="81" height="27"/>
+                      </grid>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="path"/>
+                    </properties>
+                  </component>
+                  <component id="9d1ff" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="watcher"/>
+                    </properties>
+                  </component>
+                  <component id="291f0" class="com.intellij.ui.EditorTextField" binding="hostTextField">
+                    <constraints>
+                      <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties/>
+                  </component>
+                  <component id="c55a0" class="com.intellij.ui.EditorTextField" binding="pathTextField">
+                    <constraints>
+                      <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="27"/>
+                      </grid>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="f65cf" class="com.intellij.ui.EditorTextField" binding="watcherTextField">
+                    <constraints>
+                      <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="fea7d" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="configFile"/>
+                    </properties>
+                  </component>
+                  <component id="48ef1" class="com.intellij.ui.EditorTextField" binding="configFileTextField">
+                    <constraints>
+                      <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="27"/>
+                      </grid>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="e7309" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="testemDebug"/>
+                    </properties>
+                  </component>
+                  <component id="ebe2e" class="com.intellij.ui.EditorTextField" binding="testemDebugTextField">
+                    <constraints>
+                      <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="eb9db" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="7" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="testPage"/>
+                    </properties>
+                  </component>
+                  <component id="adef1" class="com.intellij.ui.EditorTextField" binding="testPageTextField">
+                    <constraints>
+                      <grid row="7" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="5bc06" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="query"/>
+                    </properties>
+                  </component>
+                  <component id="8712" class="com.intellij.ui.EditorTextField" binding="queryTextField">
+                    <constraints>
+                      <grid row="8" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties>
+                      <text value=""/>
+                    </properties>
+                  </component>
+                  <component id="6f6ee" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="testPort"/>
+                    </properties>
+                  </component>
+                  <component id="e1098" class="com.intellij.ui.EditorTextField" binding="testPortTextField">
+                    <constraints>
+                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties/>
+                  </component>
+                  <component id="794a7" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <labelFor value="cb159"/>
+                      <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="environment"/>
+                    </properties>
+                  </component>
+                  <component id="cb159" class="javax.swing.JComboBox" binding="environmentComboBox">
+                    <constraints>
+                      <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                  </component>
+                  <grid id="1316" binding="launcherWrapperPanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                    <margin top="0" left="0" bottom="0" right="0"/>
+                    <constraints>
+                      <grid row="9" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties/>
+                    <border type="none"/>
+                    <children>
+                      <grid id="f8d57" binding="launcherPanel" layout-manager="BorderLayout" hgap="0" vgap="0">
+                        <constraints>
+                          <grid row="1" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false">
+                            <minimum-size width="-1" height="100"/>
+                          </grid>
+                        </constraints>
+                        <properties/>
+                        <border type="none"/>
+                        <children/>
+                      </grid>
+                      <component id="bd117" class="javax.swing.JRadioButton" binding="launcherDefaultRadioButton">
+                        <constraints>
+                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="launchers.option.default"/>
+                        </properties>
+                      </component>
+                      <component id="73302" class="javax.swing.JRadioButton" binding="launcherCustomRadioButton">
+                        <constraints>
+                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="launchers.option.custom"/>
+                        </properties>
+                      </component>
+                    </children>
+                  </grid>
+                </children>
+              </grid>
+            </children>
+          </grid>
+        </children>
+      </grid>
+      <grid id="eb1b3" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="63ffe" class="javax.swing.JRadioButton" binding="filterAllRadioButton">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="85" height="11"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="filter.option.all"/>
+            </properties>
+          </component>
+          <component id="5b8f5" class="javax.swing.JRadioButton" binding="filterModuleRadioButton">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="82" height="11"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="filter.option.module"/>
+            </properties>
+          </component>
+          <component id="8f5c" class="javax.swing.JRadioButton" binding="filterFilterRadioButton">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="65" height="11"/>
+              </grid>
+            </constraints>
+            <properties>
+              <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="filter.option.filter"/>
+            </properties>
+          </component>
+        </children>
+      </grid>
+      <grid id="2ffd6" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <grid id="1b8d4" binding="filterFilterPanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="e49ad" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Tests filter:"/>
+                </properties>
+              </component>
+              <component id="a2e9a" class="com.intellij.ui.EditorTextField" binding="filterTextField">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties/>
+              </component>
+            </children>
+          </grid>
+          <grid id="19424" binding="filterModulePanel" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="b8ae7" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Modules filter:"/>
+                </properties>
+              </component>
+              <component id="bc32c" class="com.intellij.ui.EditorTextField" binding="moduleTextField">
+                <constraints>
+                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties/>
+              </component>
+            </children>
+          </grid>
+        </children>
+      </grid>
+    </children>
+  </grid>
+  <buttonGroups>
+    <group name="launcherButtonGroup">
+      <member id="73302"/>
+      <member id="ac175"/>
+      <member id="bd117"/>
+    </group>
+    <group name="filterButtonGroup">
+      <member id="5b8f5"/>
+      <member id="63ffe"/>
+      <member id="8f5c"/>
+    </group>
+  </buttonGroups>
+</form>

--- a/src/main/kotlin/com/emberjs/configuration/test/ui/EmberTestSettingsEditor.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/ui/EmberTestSettingsEditor.kt
@@ -1,0 +1,215 @@
+package com.emberjs.configuration.test.ui
+
+import com.emberjs.configuration.test.EmberTestConfiguration
+import com.emberjs.configuration.test.EmberTestOptions
+import com.emberjs.configuration.test.FilterType
+import com.emberjs.configuration.test.LaunchType
+import com.emberjs.configuration.utils.PublicStringAddEditDeleteListPanel
+import com.intellij.openapi.options.ConfigurationException
+import com.intellij.openapi.options.SettingsEditor
+import com.intellij.openapi.ui.Messages
+import com.intellij.ui.CollectionComboBoxModel
+import com.intellij.ui.EditorTextField
+import com.intellij.ui.HideableDecorator
+import com.intellij.ui.IdeBorderFactory
+import org.jetbrains.annotations.NotNull
+import java.util.*
+import javax.swing.*
+
+class EmberTestSettingsEditor : SettingsEditor<EmberTestConfiguration>() {
+    private var myPanel: JPanel? = null
+    private var advancedSettings: JPanel? = null
+    private var advancedSettingsWrapper: JPanel? = null
+    private var launcherPanel: JPanel? = null
+    private var launcherWrapperPanel: JPanel? = null
+
+    private var testPortTextField: EditorTextField? = null
+    private var environmentComboBox: JComboBox<String>? = null
+
+    private var hostTextField: EditorTextField? = null
+    private var configFileTextField: EditorTextField? = null
+    private var filterTextField: EditorTextField? = null
+    private var moduleTextField: EditorTextField? = null
+    private var watcherTextField: EditorTextField? = null
+    private var testemDebugTextField: EditorTextField? = null
+    private var testPageTextField: EditorTextField? = null
+    private var pathTextField: EditorTextField? = null
+    private var queryTextField: EditorTextField? = null
+
+    private var launcherDefaultRadioButton: JRadioButton? = null
+    private var launcherCustomRadioButton: JRadioButton? = null
+
+    private var filterAllRadioButton: JRadioButton? = null
+    private var filterModuleRadioButton: JRadioButton? = null
+    private var filterFilterRadioButton: JRadioButton? = null
+
+    private var launchAddEditDeleteListPanel: PublicStringAddEditDeleteListPanel? = null
+
+    private var filterModulePanel: JPanel? = null
+    private var filterFilterPanel: JPanel? = null
+
+    private var launcherButtonGroup: ButtonGroup? = null
+    private var filterButtonGroup: ButtonGroup? = null
+
+    val bundle: ResourceBundle = ResourceBundle.getBundle("com.emberjs.locale.EmberTestConfigurationEditor")
+    val launchers: MutableList<String> = mutableListOf()
+
+    private val mappings = mutableListOf(
+            testPortTextField to EmberTestOptions::testPort,
+            environmentComboBox to EmberTestOptions::environment,
+            hostTextField to EmberTestOptions::host,
+            configFileTextField to EmberTestOptions::configFile,
+            filterTextField to EmberTestOptions::filter,
+            moduleTextField to EmberTestOptions::module,
+            watcherTextField to EmberTestOptions::watcher,
+            testemDebugTextField to EmberTestOptions::testemDebug,
+            pathTextField to EmberTestOptions::path,
+            queryTextField to EmberTestOptions::query,
+            testPageTextField to EmberTestOptions::testPage
+    )
+
+    private val launchTypeToRadioButton = mutableListOf(
+            LaunchType.DEFAULT to launcherDefaultRadioButton,
+            LaunchType.CUSTOM to launcherCustomRadioButton
+    )
+
+    private val filterTypeToRadioButton = mutableListOf(
+            FilterType.ALL to filterAllRadioButton,
+            FilterType.FILTER to filterFilterRadioButton,
+            FilterType.MODULE to filterModuleRadioButton
+    )
+
+    override fun resetEditorFrom(configuration: EmberTestConfiguration) {
+        val launchType = try {
+            LaunchType.valueOf(configuration.options.launchOption.value)
+        } catch (_: Exception) {
+            LaunchType.DEFAULT
+        }
+        val filterType = try {
+            FilterType.valueOf(configuration.options.filterOption.value)
+        } catch (_: Exception) {
+            FilterType.ALL
+        }
+
+        handleLaunchRadio(launchType)
+        handleFilterRadio(filterType)
+
+        launchTypeToRadioButton.forEach({ (first, second) ->
+            second!!.isSelected = first.value == launchType.toString()
+        })
+        filterTypeToRadioButton.forEach({ (first, second) ->
+            second!!.isSelected = first.value == filterType.toString()
+        })
+
+        mappings
+                .filter { it.first != null }
+                .forEach { (first, second) -> first?.let { second.get(configuration.options).writeTo(it) } }
+    }
+
+    @Throws(ConfigurationException::class)
+    override fun applyEditorTo(configuration: EmberTestConfiguration) {
+        mappings
+                .filter { it.first != null }
+                .forEach { (first, second) -> first?.let { second.get(configuration.options).readFrom(it) } }
+    }
+
+    @NotNull
+    override fun createEditor(): JComponent {
+        // Create the collapsible component for advances settings
+        HideableDecorator(advancedSettingsWrapper, bundle.getString("advanced"), false).apply {
+            setContentComponent(advancedSettings as JComponent)
+            setOn(false)
+        }
+
+        // somehow the ButtonGroup aren't bound :(
+        launcherButtonGroup = ButtonGroup().apply {
+            add(launcherCustomRadioButton)
+            add(launcherDefaultRadioButton)
+        }
+
+        filterButtonGroup = ButtonGroup().apply {
+            add(filterAllRadioButton)
+            add(filterModuleRadioButton)
+            add(filterFilterRadioButton)
+        }
+
+        mappings.add(filterButtonGroup to EmberTestOptions::filterOption)
+        mappings.add(launcherButtonGroup to EmberTestOptions::launchOption)
+
+        environmentComboBox?.model = CollectionComboBoxModel<String>().apply {
+            add("test")
+            add("development")
+            add("production")
+        }
+
+        launchAddEditDeleteListPanel = object : PublicStringAddEditDeleteListPanel(null, launchers) {
+            override fun editSelectedItem(item: String?): String? {
+                val message = Messages.showInputDialog(this,
+                        bundle.getString("launchers.edit.message"),
+                        bundle.getString("launchers.edit.title"),
+                        Messages.getQuestionIcon(),
+                        item, null)
+
+                return if (message === null || message.isEmpty()) {
+                    null
+                } else {
+                    message
+                }
+            }
+
+            override fun findItemToAdd(): String? {
+                val message = Messages.showInputDialog(this,
+                        bundle.getString("launchers.create.message"),
+                        bundle.getString("launchers.create.title"),
+                        Messages.getQuestionIcon(),
+                        "", null)
+
+                return if (message === null || message.isEmpty()) {
+                    null
+                } else {
+                    message
+                }
+            }
+        }
+
+        launchTypeToRadioButton.forEach({ (first, second) ->
+            second!!.actionCommand = first.value
+            second.addActionListener { handleLaunchRadio(first) }
+        })
+        filterTypeToRadioButton.forEach({ (first, second) ->
+            second!!.actionCommand = first.value
+            second.addActionListener { handleFilterRadio(first) }
+        })
+
+        launcherPanel!!.add(launchAddEditDeleteListPanel)
+        mappings.add(launchAddEditDeleteListPanel to EmberTestOptions::launch)
+
+        launcherWrapperPanel!!.border = IdeBorderFactory.createTitledBorder(bundle.getString("launchers"), false)
+
+        return myPanel as JComponent
+    }
+
+    fun handleLaunchRadio(type: LaunchType) {
+        when (type) {
+            LaunchType.CUSTOM -> launcherPanel!!.isVisible = true
+            else -> launcherPanel!!.isVisible = false
+        }
+    }
+
+    fun handleFilterRadio(type: FilterType) {
+        when (type) {
+            FilterType.MODULE -> {
+                filterModulePanel!!.isVisible = true
+                filterFilterPanel!!.isVisible = false
+            }
+            FilterType.FILTER -> {
+                filterModulePanel!!.isVisible = false
+                filterFilterPanel!!.isVisible = true
+            }
+            else -> {
+                filterModulePanel!!.isVisible = false
+                filterFilterPanel!!.isVisible = false
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/emberjs/configuration/utils/PublicStringAddEditDeleteListPanel.kt
+++ b/src/main/kotlin/com/emberjs/configuration/utils/PublicStringAddEditDeleteListPanel.kt
@@ -1,0 +1,19 @@
+package com.emberjs.configuration.utils
+
+import com.intellij.ui.AddEditDeleteListPanel
+
+abstract class PublicStringAddEditDeleteListPanel(
+        title: String?,
+        initialList: List<String>
+) : AddEditDeleteListPanel<String>(title, initialList) {
+    fun replaceItems(items: List<String>) {
+        myListModel.clear()
+
+        if (items.isNotEmpty()) {
+
+            items.forEach { myListModel.addElement(it) }
+
+            myList.setSelectedValue(items.last(), false)
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -68,6 +68,10 @@
         <!-- ember serve -->
         <programRunner implementation="com.emberjs.configuration.serve.EmberServeProgramRunner"/>
         <configurationType implementation="com.emberjs.configuration.serve.EmberServeConfigurationType"/>
+
+        <!-- ember test -->
+        <programRunner implementation="com.emberjs.configuration.test.EmberTestProgramRunner"/>
+        <configurationType implementation="com.emberjs.configuration.test.EmberTestConfigurationType"/>
     </extensions>
 
     <extensions defaultExtensionNs="JavaScript">

--- a/src/main/resources/com/emberjs/locale/EmberTestConfigurationEditor.properties
+++ b/src/main/resources/com/emberjs/locale/EmberTestConfigurationEditor.properties
@@ -1,0 +1,27 @@
+testPort=Test port:
+host=Host:
+environment=Environment:
+path=Path:
+watcher=Watcher:
+configFile=Config file:
+filter=Filter:
+module=Module:
+testemDebug=Testem debug:
+testPage=Test page:
+query=Query:
+
+advanced=Advanced settings
+
+launchers=Launchers
+launchers.edit.title=Edit launcher
+launchers.edit.message=Input a testem launcher (i.e. Chrome)
+
+launchers.option.default=Default Browsers
+launchers.option.custom=Custom Browsers
+
+launchers.create.title=Create launcher
+launchers.create.message=Create a testem launcher (i.e. Chrome)
+
+filter.option.all=All tests
+filter.option.module=Module
+filter.option.filter=Filter


### PR DESCRIPTION
This PR adds a run configuration that attaches the generated console to intellij `com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil` which generates the integrated test ui:

![20171021-121058](https://user-images.githubusercontent.com/1205444/31939440-b1dc9160-b8ba-11e7-821b-5c2c93bf2ded.png)

There isn't any conversion going on because it only pipes testem teamcity output to the test runner.
This means we don't get the most user friendly output right now but once https://github.com/testem/testem/pull/1188 and https://github.com/testem/testem/issues/1187 are resolved, it should display durations and group the tests as seen above.

This PR closes #125

I've added a small paragraph about the test run configuration, without a screenshot, to `features.md`.