### PR TITLE
Add typescript support

### DIFF
--- a/src/main/kotlin/com/emberjs/icons/EmberIconProvider.kt
+++ b/src/main/kotlin/com/emberjs/icons/EmberIconProvider.kt
@@ -16,8 +16,8 @@ class EmberIconProvider : IconProvider() {
 
     fun getIcon(psiFile: PsiFile?) = psiFile?.virtualFile?.let { getIcon(it) }
 
-    fun getIcon(file: VirtualFile) = when {
-        file.extension == "js" -> EmberName.from(file)?.let { getIcon(it) }
+    fun getIcon(file: VirtualFile) = when (file.extension) {
+        "js", "ts" -> EmberName.from(file)?.let { getIcon(it) }
         else -> null
     }
 

--- a/src/main/kotlin/com/emberjs/index/EmberNameIndex.kt
+++ b/src/main/kotlin/com/emberjs/index/EmberNameIndex.kt
@@ -25,7 +25,7 @@ class EmberNameIndex() : ScalarIndexExtension<EmberName>() {
 
     companion object {
         val NAME: ID<EmberName, Void> = ID.create("ember.names")
-        private val FILE_EXTENSIONS = setOf("js", "hbs", "handlebars")
+        private val FILE_EXTENSIONS = setOf("js", "ts", "hbs", "handlebars")
 
         private val index by lazy { FileBasedIndex.getInstance() }
 

--- a/src/test/kotlin/com/emberjs/index/EmberNameIndexTest.kt
+++ b/src/test/kotlin/com/emberjs/index/EmberNameIndexTest.kt
@@ -29,6 +29,7 @@ class EmberNameIndexTest : LightPlatformCodeInsightFixtureTestCase() {
     fun testExample() = doTest(
             "controller:application",
             "controller:user/index",
+            "controller:user/new",
             "route:index",
             "helper-test:format-number",
             "acceptance-test:user-page")


### PR DESCRIPTION
Make everything work with `.ts` files in addition to `.js`:

- [x] index typescript files so they show up in class search
- [x] use the custom icons for typescript files in the project tree
- [x] can navigate to typescript components from templates

... I think this is all that needs to be done to support typescript. Did I miss something?

/cc @chriskrycho