### PR TITLE
Use node interpreter path from the project settings

### DIFF
--- a/src/main/kotlin/com/emberjs/cli/EmberCli.kt
+++ b/src/main/kotlin/com/emberjs/cli/EmberCli.kt
@@ -1,11 +1,14 @@
 package com.emberjs.cli
 
 import com.intellij.execution.configurations.GeneralCommandLine
+import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterManager
+import com.intellij.javascript.nodejs.interpreter.local.NodeJsLocalInterpreter
+import com.intellij.openapi.project.Project
 import org.apache.commons.lang.SystemUtils
 import java.io.BufferedReader
 import java.util.concurrent.TimeUnit
 
-class EmberCli(vararg val parameters: String) {
+class EmberCli(val project: Project, vararg val parameters: String) {
 
     var workDirectory: String? = null
 
@@ -14,8 +17,13 @@ class EmberCli(vararg val parameters: String) {
             SystemUtils.IS_OS_WINDOWS -> ".cmd"
             else -> ""
         }
+
+        val interpreter = NodeJsInterpreterManager.getInstance(project).default as? NodeJsLocalInterpreter
+        val node = interpreter?.interpreterSystemDependentPath ?: "node"
+
         val workDir = workDirectory
-        return GeneralCommandLine("$workDir/node_modules/.bin/ember$suffix").apply {
+        return GeneralCommandLine(node).apply {
+            addParameter("$workDir/node_modules/.bin/ember$suffix")
             addParameters(*parameters)
             withWorkDirectory(workDir)
         }

--- a/src/main/kotlin/com/emberjs/cli/EmberCliGenerateTask.kt
+++ b/src/main/kotlin/com/emberjs/cli/EmberCliGenerateTask.kt
@@ -31,7 +31,7 @@ class EmberCliGenerateTask(project: Project, val workDir: VirtualFile, val templ
         indicator.isIndeterminate = true
 
         indicator.log("Preparing ember command ...")
-        val cli = EmberCli("generate", template, name)
+        val cli = EmberCli(project, "generate", template, name)
                 .apply { workDirectory = workDir.path }
 
                 LocalHistory.getInstance().startAction(title).use {

--- a/src/main/kotlin/com/emberjs/configuration/EmberCommandLineState.kt
+++ b/src/main/kotlin/com/emberjs/configuration/EmberCommandLineState.kt
@@ -12,7 +12,7 @@ class EmberCommandLineState(environment: ExecutionEnvironment) : CommandLineStat
         val configuration = (environment.runProfile as EmberConfiguration)
         val argList = configuration.options.toCommandLineOptions()
 
-        val cmd = EmberCli(configuration.command, *argList)
+        val cmd = EmberCli(environment.project, configuration.command, *argList)
                 .apply { workDirectory = environment.project.basePath }
                 .commandLine()
                 .apply {


### PR DESCRIPTION
Use the project's node executable for "ember serve" run configuration and "ember generate" menu actions. Fall back to calling `node` on the path, e.g. if the nodejs plugin isn't installed.

Fixes #177