### PR TITLE
run ember binary directly

### DIFF
--- a/src/main/kotlin/com/emberjs/cli/EmberCli.kt
+++ b/src/main/kotlin/com/emberjs/cli/EmberCli.kt
@@ -1,10 +1,8 @@
 package com.emberjs.cli
 
 import com.intellij.execution.configurations.GeneralCommandLine
-import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterManager
-import com.intellij.javascript.nodejs.interpreter.local.NodeJsLocalInterpreter
 import com.intellij.openapi.project.Project
-import org.apache.commons.lang.SystemUtils
+import org.apache.commons.lang3.SystemUtils
 import java.io.BufferedReader
 import java.util.concurrent.TimeUnit
 
@@ -18,12 +16,9 @@ class EmberCli(val project: Project, vararg val parameters: String) {
             else -> ""
         }
 
-        val interpreter = NodeJsInterpreterManager.getInstance(project).default as? NodeJsLocalInterpreter
-        val node = interpreter?.interpreterSystemDependentPath ?: "node"
-
+        val emberBin = "$workDirectory/node_modules/.bin/ember$suffix"
         val workDir = workDirectory
-        return GeneralCommandLine(node).apply {
-            addParameter("$workDir/node_modules/.bin/ember$suffix")
+        return GeneralCommandLine(emberBin).apply {
             addParameters(*parameters)
             withWorkDirectory(workDir)
         }


### PR DESCRIPTION
This PR changes the behavior to never invoke the ember binary with node but use the generated `.bin/ember` directly.

On windows it's a `.cmd` that automatically finds node.
On linux/darwin a js file with a shebang line to run it with node

should fix #207 and maybe #191.

Please don't merge this yet, as I haven't had time to check if the tests are ok (or go ahead if CI is ok). 

It works on windows (tried in a modern.ie vm) and linux.

![20180614-220626](https://user-images.githubusercontent.com/1205444/41435492-431c7a5c-701f-11e8-9b5a-793a6949781a.png)

@Hucster can you maybe check this branch out and build the plugin locally to confirm that it's fixed?
