### PR TITLE
Add option to specify a custom module to run the run configuration in

### DIFF
--- a/src/main/kotlin/com/emberjs/configuration/EmberCommandLineState.kt
+++ b/src/main/kotlin/com/emberjs/configuration/EmberCommandLineState.kt
@@ -2,6 +2,7 @@ package com.emberjs.configuration
 
 import com.emberjs.cli.EmberCli
 import com.emberjs.utils.emberRoot
+import com.emberjs.utils.parentModule
 import com.intellij.execution.configurations.CommandLineState
 import com.intellij.execution.process.KillableColoredProcessHandler
 import com.intellij.execution.process.ProcessHandler
@@ -14,7 +15,10 @@ open class EmberCommandLineState(environment: ExecutionEnvironment) : CommandLin
         val configuration = (environment.runProfile as EmberConfiguration)
         val argList = configuration.options.toCommandLineOptions()
 
-        val workingDirectory = environment.dataContext?.getData(LangDataKeys.MODULE)?.emberRoot?.path ?:
+        val workingDirectory =
+                // if module configured, use that as workDirectory
+                configuration.module?.moduleFile?.parentModule?.path ?:
+                environment.dataContext?.getData(LangDataKeys.MODULE)?.emberRoot?.path ?:
                 environment.project.basePath
 
         val cmd = EmberCli(environment.project, configuration.command, *argList)

--- a/src/main/kotlin/com/emberjs/configuration/EmberConfiguration.kt
+++ b/src/main/kotlin/com/emberjs/configuration/EmberConfiguration.kt
@@ -1,6 +1,9 @@
 package com.emberjs.configuration
 
+import com.intellij.openapi.module.Module
+
 interface EmberConfiguration {
     val command: String
     val options: EmberOptions
+    var module: Module?
 }

--- a/src/main/kotlin/com/emberjs/configuration/EmberConfigurationBase.kt
+++ b/src/main/kotlin/com/emberjs/configuration/EmberConfigurationBase.kt
@@ -1,0 +1,40 @@
+package com.emberjs.configuration
+
+import com.emberjs.configuration.utils.ElementUtils
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.configurations.RunConfigurationBase
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.Project
+import org.jdom.Element
+
+abstract class EmberConfigurationBase(project: Project, factory: ConfigurationFactory, name: String) :
+        RunConfigurationBase(project, factory, name),
+        EmberConfiguration {
+    override var module: Module? = null
+
+    override fun writeExternal(element: Element) {
+        super.writeExternal(element)
+        element.let {
+            options.fields().forEach { optionsField -> optionsField.writeTo(element) }
+        }
+
+        val moduleName = module?.name
+        when (moduleName) {
+            is String -> ElementUtils.writeString(element, "NAME", moduleName, "module")
+            else -> ElementUtils.removeField(element, "NAME", "module")
+        }
+    }
+
+    override fun readExternal(element: Element) {
+        super.readExternal(element)
+        element.let {
+            options.fields().forEach { optionsField -> optionsField.readFrom(element) }
+        }
+
+        ElementUtils.readString(element, "NAME", "module")?.let { moduleString ->
+            module = ModuleManager.getInstance(project).modules.find { it.name == moduleString }
+        }
+    }
+
+}

--- a/src/main/kotlin/com/emberjs/configuration/serve/EmberServeConfiguration.kt
+++ b/src/main/kotlin/com/emberjs/configuration/serve/EmberServeConfiguration.kt
@@ -1,19 +1,21 @@
 package com.emberjs.configuration.serve
 
 import com.emberjs.configuration.EmberCommandLineState
-import com.emberjs.configuration.EmberConfiguration
+import com.emberjs.configuration.EmberConfigurationBase
 import com.emberjs.configuration.serve.ui.EmberServeSettingsEditor
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.Executor
-import com.intellij.execution.configurations.*
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
-import org.jdom.Element
 import org.jetbrains.annotations.NotNull
 import org.jetbrains.annotations.Nullable
 
-class EmberServeConfiguration(project: Project, factory: ConfigurationFactory, name: String) : RunConfigurationBase(project, factory, name), EmberConfiguration {
+class EmberServeConfiguration(project: Project, factory: ConfigurationFactory, name: String) :
+        EmberConfigurationBase(project, factory, name) {
     override val options = EmberServeOptions()
     override val command: String = "serve"
 
@@ -22,28 +24,9 @@ class EmberServeConfiguration(project: Project, factory: ConfigurationFactory, n
         return EmberServeSettingsEditor()
     }
 
-    @Throws(RuntimeConfigurationException::class)
-    override fun checkConfiguration() {
-
-    }
-
     @Nullable
     @Throws(ExecutionException::class)
     override fun getState(@NotNull executor: Executor, @NotNull executionEnvironment: ExecutionEnvironment): RunProfileState? {
         return EmberCommandLineState(executionEnvironment)
-    }
-
-    override fun writeExternal(element: Element) {
-        super.writeExternal(element)
-        element.let {
-            options.fields().forEach { optionsField -> optionsField.writeTo(element)}
-        }
-    }
-
-    override fun readExternal(element: Element) {
-        super.readExternal(element)
-        element.let {
-            options.fields().forEach { optionsField -> optionsField.readFrom(element) }
-        }
     }
 }

--- a/src/main/kotlin/com/emberjs/configuration/serve/ui/EmberServeSettingsEditor.form
+++ b/src/main/kotlin/com/emberjs/configuration/serve/ui/EmberServeSettingsEditor.form
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.emberjs.configuration.serve.ui.EmberServeSettingsEditor">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="523" height="399"/>
+      <xy x="20" y="20" width="659" height="493"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <grid id="5303a" binding="advancedSettingsWrapper" layout-manager="BorderLayout" hgap="0" vgap="0">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -284,10 +284,10 @@
           </grid>
         </children>
       </grid>
-      <grid id="eb1b3" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="eb1b3" binding="emberServePanel" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -319,6 +319,32 @@
             <constraints>
               <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
+              </grid>
+            </constraints>
+            <properties/>
+          </component>
+        </children>
+      </grid>
+      <grid id="12771" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="11597" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="com/emberjs/locale/EmberServeConfigurationEditor" key="project.module"/>
+            </properties>
+          </component>
+          <component id="e1099" class="com.intellij.application.options.ModulesComboBox" binding="myModulesComboBox">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                <preferred-size width="59" height="30"/>
               </grid>
             </constraints>
             <properties/>

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfiguration.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfiguration.kt
@@ -1,6 +1,6 @@
 package com.emberjs.configuration.test
 
-import com.emberjs.configuration.EmberConfiguration
+import com.emberjs.configuration.EmberConfigurationBase
 import com.emberjs.configuration.test.ui.EmberTestSettingsEditor
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.Executor
@@ -8,11 +8,10 @@ import com.intellij.execution.configurations.*
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
-import org.jdom.Element
 import org.jetbrains.annotations.NotNull
 import org.jetbrains.annotations.Nullable
 
-class EmberTestConfiguration(project: Project, factory: ConfigurationFactory, name: String) : RunConfigurationBase(project, factory, name), EmberConfiguration {
+class EmberTestConfiguration(project: Project, factory: ConfigurationFactory, name: String) : EmberConfigurationBase(project, factory, name) {
     override val options = EmberTestOptions()
     override val command: String = "test"
 
@@ -21,28 +20,9 @@ class EmberTestConfiguration(project: Project, factory: ConfigurationFactory, na
         return EmberTestSettingsEditor()
     }
 
-    @Throws(RuntimeConfigurationException::class)
-    override fun checkConfiguration() {
-
-    }
-
     @Nullable
     @Throws(ExecutionException::class)
     override fun getState(@NotNull executor: Executor, @NotNull executionEnvironment: ExecutionEnvironment): RunProfileState? {
         return EmberTestCommandLineState(executionEnvironment)
-    }
-
-    override fun writeExternal(element: Element) {
-        super.writeExternal(element)
-        element.let {
-            options.fields().forEach { optionsField -> optionsField.writeTo(element)}
-        }
-    }
-
-    override fun readExternal(element: Element) {
-        super.readExternal(element)
-        element.let {
-            options.fields().forEach { optionsField -> optionsField.readFrom(element) }
-        }
     }
 }

--- a/src/main/kotlin/com/emberjs/configuration/test/ui/EmberTestSettingsEditor.form
+++ b/src/main/kotlin/com/emberjs/configuration/test/ui/EmberTestSettingsEditor.form
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="com.emberjs.configuration.test.ui.EmberTestSettingsEditor">
-  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="560" height="559"/>
+      <xy x="20" y="20" width="560" height="688"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <grid id="5303a" binding="advancedSettingsWrapper" layout-manager="BorderLayout" hgap="0" vgap="0">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -225,10 +225,10 @@
           </grid>
         </children>
       </grid>
-      <grid id="eb1b3" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="eb1b3" binding="emberTestFilterPanel" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -268,7 +268,7 @@
       <grid id="2ffd6" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -325,6 +325,35 @@
               </component>
             </children>
           </grid>
+        </children>
+      </grid>
+      <grid id="74127" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="d1c28" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="project.module"/>
+            </properties>
+          </component>
+          <component id="e1100" class="com.intellij.application.options.ModulesComboBox" binding="myModulesComboBox">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
+          <hspacer id="d6cb0">
+            <constraints>
+              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+          </hspacer>
         </children>
       </grid>
     </children>

--- a/src/main/kotlin/com/emberjs/configuration/utils/ElementUtils.kt
+++ b/src/main/kotlin/com/emberjs/configuration/utils/ElementUtils.kt
@@ -7,22 +7,28 @@ import org.jdom.Element
 
 class ElementUtils {
     companion object {
-        fun writeString(element: Element, name: String, value: String) {
-            val opt = org.jdom.Element("option")
+        fun writeString(element: Element, name: String, value: String, elementName: String = "option") {
+            val opt = org.jdom.Element(elementName)
             opt.setAttribute("name", name)
             opt.setAttribute("value", value)
             element.addContent(opt)
         }
 
-        fun readString(element: Element, name: String): String? =
+        fun readString(element: Element, name: String, elementName: String = "option"): String? =
                 element.children
-                        .find { it.name == "option" && it.getAttributeValue("name") == name }
+                        .find { it.name == elementName && it.getAttributeValue("name") == name }
                         ?.getAttributeValue("value")
 
-        fun writeBool(element: Element, name: String, value: Boolean) {
-            writeString(element, name, value.toString())
+        fun writeBool(element: Element, name: String, value: Boolean, elementName: String = "option") {
+            writeString(element, name, value.toString(), elementName)
         }
 
-        fun readBool(element: Element, name: String) = readString(element, name)?.toBoolean()
+        fun readBool(element: Element, name: String, elementName: String = "option") = readString(element, name, elementName)?.toBoolean()
+
+        fun removeField(element: Element, name: String, elementName: String = "option") {
+            element.children
+                    .find { it.name == elementName && it.getAttributeValue("name") == name }
+                    ?.let { it.parent.removeContent(it) }
+        }
     }
 }

--- a/src/main/resources/com/emberjs/locale/EmberServeConfigurationEditor.properties
+++ b/src/main/resources/com/emberjs/locale/EmberServeConfigurationEditor.properties
@@ -5,6 +5,9 @@ host=Host:
 environment=Environment:
 outputPath=Output path:
 watcher=Watcher:
+project.module=Module:
+
+advanced=Advanced settings
 
 tab.ssl=SSL
 tab.livereload=Livereload
@@ -22,3 +25,5 @@ livereload.port=Livereload port:
 proxy.proxy=Proxy:
 proxy.secureProxy=Secure proxy:
 proxy.transparentProxy=Transparent proxy:
+
+configuration.title=Serve configuration:

--- a/src/main/resources/com/emberjs/locale/EmberTestConfigurationEditor.properties
+++ b/src/main/resources/com/emberjs/locale/EmberTestConfigurationEditor.properties
@@ -9,6 +9,7 @@ module=Module:
 testemDebug=Testem debug:
 testPage=Test page:
 query=Query:
+project.module=Module:
 
 advanced=Advanced settings
 
@@ -25,3 +26,5 @@ launchers.create.message=Create a testem launcher (i.e. Chrome)
 filter.option.all=All tests
 filter.option.module=Module
 filter.option.filter=Filter
+
+configuration.title=Test configuration:


### PR DESCRIPTION
this fixes #181 and potentially #188 and allows us to use run configuration in yarn workspace projects \o/

It adds a new configuration element `<module name="NAME" value="main" />` which persists the configured run configuration module name.
I've used a `module` element here as it's not the same domain as other regular `<option>` fields. (This is also how intellij does it if `ModuleBasedConfiguration` is used. We can't use that right now as it requires a valid SDK).

Now every all run configurations have the ability to set a `module`

Here's how it looks like in the dev IDE:

![20180714-120752](https://user-images.githubusercontent.com/1205444/42723749-72c17030-8764-11e8-8e40-c1fbe7c36e44.png)
![20180714-120743](https://user-images.githubusercontent.com/1205444/42723750-72e32838-8764-11e8-9f73-cd3bd4ed16cd.png)
![20180714-120735](https://user-images.githubusercontent.com/1205444/42723751-7302f8b6-8764-11e8-91f7-7d4f790cfd5e.png)
![20180714-120745](https://user-images.githubusercontent.com/1205444/42723772-ff4f00c6-8764-11e8-83c9-36b191646dfd.png)

