### PR TITLE
fix class navigation in 2018.2

### DIFF
--- a/src/main/kotlin/com/emberjs/navigation/EmberGotoClassContributor.kt
+++ b/src/main/kotlin/com/emberjs/navigation/EmberGotoClassContributor.kt
@@ -6,17 +6,25 @@ import com.emberjs.index.EmberNameIndex
 import com.emberjs.resolver.EmberName
 import com.emberjs.utils.isInRepoAddon
 import com.emberjs.utils.parentEmberModule
-import com.intellij.navigation.ChooseByNameContributor
 import com.intellij.navigation.DelegatingItemPresentation
+import com.intellij.navigation.GotoClassContributor
 import com.intellij.navigation.NavigationItem
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
 import com.intellij.util.indexing.FindSymbolParameters.searchScopeFor
 
-class EmberGotoClassContributor() : ChooseByNameContributor {
-
+class EmberGotoClassContributor : GotoClassContributor {
     private val iconProvider by lazy { EmberIconProvider() }
+
+    override fun getQualifiedName(item: NavigationItem?): String? {
+        if (item is DelegatingNavigationItem) {
+            return item.presentation?.presentableText?.replace("-", qualifiedNameSeparator)
+        }
+        return null
+    }
+
+    override fun getQualifiedNameSeparator() = " "
 
     /**
      * Get all entries from the module index and extract the `displayName` property.


### PR DESCRIPTION
After upgrading to 2018.2 today the class autocomplete wasn't working properly.

For example:
![screen shot 2018-07-25 at 11 47 34 am](https://user-images.githubusercontent.com/752885/43221120-c1b14cf2-9000-11e8-932d-89193d0b0f30.png)
![screen shot 2018-07-25 at 11 47 46 am](https://user-images.githubusercontent.com/752885/43221125-c5333836-9000-11e8-96fe-07cef6f69353.png)

IntelliJ filters out the items which don't match the qualified name, which defaults to the filename `"foo.js"`. Now we customize the qualified name.

Fixed:
![screen shot 2018-07-25 at 11 41 42 am](https://user-images.githubusercontent.com/752885/43221132-cc235964-9000-11e8-89d3-ffa8ce80557d.png)
