### PR TITLE
Update IntelliJ Gradle plugin to v0.3.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 }
 
 plugins {
-    id "org.jetbrains.intellij" version "0.3.2"
+    id "org.jetbrains.intellij" version "0.3.11"
     id "com.zoltu.git-versioning" version "2.0.28"
 }
 


### PR DESCRIPTION
This will enable us to update Gradle itself again.