### PR TITLE
chore: update to latest intellij EAP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         kotlinVersion = '1.2.71'
 
         // see https://www.jetbrains.com/intellij-repository/releases/
-        intellijVersion = '183.2635.13'
+        intellijVersion = '183.2940.10'
 
         // see https://plugins.jetbrains.com/idea/plugin/6884-handlebars-mustache
         handlebarsPluginVersion = '183.2407.4'

--- a/src/main/kotlin/com/emberjs/configuration/EmberConfigurationBase.kt
+++ b/src/main/kotlin/com/emberjs/configuration/EmberConfigurationBase.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.project.Project
 import org.jdom.Element
 
 abstract class EmberConfigurationBase(project: Project, factory: ConfigurationFactory, name: String) :
-        RunConfigurationBase(project, factory, name),
+        RunConfigurationBase<Any>(project, factory, name),
         EmberConfiguration {
     override var module: Module? = null
 


### PR DESCRIPTION
This makes intellij-emberjs compatible with the latest EAP (2018.3 EAP build 183.2940.10)