### PR TITLE
Allow users to configure node interpreter

### DIFF
--- a/src/main/kotlin/com/emberjs/configuration/BooleanOptionsField.kt
+++ b/src/main/kotlin/com/emberjs/configuration/BooleanOptionsField.kt
@@ -14,14 +14,14 @@ class BooleanOptionsField(
     override fun writeTo(component: Any) {
         when (component) {
             is JCheckBox -> component.isSelected = value
-            is Element -> ElementUtils.writeBool(component, this.field, this.value)
+            is Element -> ElementUtils.writeBool(component, value = this.value, name = this.field)
         }
     }
 
     override fun readFrom(component: Any) {
         when (component) {
             is JCheckBox -> value = component.isSelected
-            is Element -> this.value = ElementUtils.readBool(component, this.field) ?: this.default
+            is Element -> this.value = ElementUtils.readBool(component, name = this.field) ?: this.default
         }
     }
 }

--- a/src/main/kotlin/com/emberjs/configuration/EmberCommandLineState.kt
+++ b/src/main/kotlin/com/emberjs/configuration/EmberCommandLineState.kt
@@ -22,7 +22,10 @@ open class EmberCommandLineState(environment: ExecutionEnvironment) : CommandLin
                 environment.project.basePath
 
         val cmd = EmberCli(environment.project, configuration.command, *argList)
-                .apply { workDirectory = workingDirectory }
+                .apply {
+                    workDirectory = workingDirectory
+                    nodeInterpreter = configuration.nodeInterpreter
+                }
                 .commandLine()
                 .apply {
                     // taken from intellij-rust

--- a/src/main/kotlin/com/emberjs/configuration/EmberConfiguration.kt
+++ b/src/main/kotlin/com/emberjs/configuration/EmberConfiguration.kt
@@ -6,4 +6,5 @@ interface EmberConfiguration {
     val command: String
     val options: EmberOptions
     var module: Module?
+    var nodeInterpreter: String?
 }

--- a/src/main/kotlin/com/emberjs/configuration/EmberConfigurationBase.kt
+++ b/src/main/kotlin/com/emberjs/configuration/EmberConfigurationBase.kt
@@ -12,6 +12,7 @@ abstract class EmberConfigurationBase(project: Project, factory: ConfigurationFa
         RunConfigurationBase<Any>(project, factory, name),
         EmberConfiguration {
     override var module: Module? = null
+    override var nodeInterpreter: String? = null
 
     override fun writeExternal(element: Element) {
         super.writeExternal(element)
@@ -21,8 +22,13 @@ abstract class EmberConfigurationBase(project: Project, factory: ConfigurationFa
 
         val moduleName = module?.name
         when (moduleName) {
-            is String -> ElementUtils.writeString(element, "NAME", moduleName, "module")
-            else -> ElementUtils.removeField(element, "NAME", "module")
+            is String -> ElementUtils.writeString(element, "module", moduleName, "NAME")
+            else -> ElementUtils.removeField(element, "module", "NAME")
+        }
+
+        when (nodeInterpreter) {
+            is String -> ElementUtils.writeString(element, "node-interpreter", nodeInterpreter!!)
+            else -> ElementUtils.removeField(element, "node-interpreter")
         }
     }
 
@@ -32,8 +38,11 @@ abstract class EmberConfigurationBase(project: Project, factory: ConfigurationFa
             options.fields().forEach { optionsField -> optionsField.readFrom(element) }
         }
 
-        ElementUtils.readString(element, "NAME", "module")?.let { moduleString ->
+        ElementUtils.readString(element, "module", "NAME")?.let { moduleString ->
             module = ModuleManager.getInstance(project).modules.find { it.name == moduleString }
+        }
+        ElementUtils.readString(element, "node-interpreter")?.let { elementNodeInterpreter ->
+            nodeInterpreter = elementNodeInterpreter
         }
     }
 

--- a/src/main/kotlin/com/emberjs/configuration/OptionsField.kt
+++ b/src/main/kotlin/com/emberjs/configuration/OptionsField.kt
@@ -1,8 +1,5 @@
 package com.emberjs.configuration
 
-import org.jdom.Element
-import javax.swing.JComponent
-
 abstract class OptionsField<T>(
         val default: T,
         val field: String,

--- a/src/main/kotlin/com/emberjs/configuration/StringOptionsField.kt
+++ b/src/main/kotlin/com/emberjs/configuration/StringOptionsField.kt
@@ -17,7 +17,7 @@ class StringOptionsField(
 
     override fun writeTo(component: Any) {
         when (component) {
-            is Element -> ElementUtils.writeString(component, this.field, this.value)
+            is Element -> ElementUtils.writeString(component, value = this.value, name = this.field)
             is EditorTextField -> component.apply {
                 text = value
                 setPlaceholder(default)
@@ -37,7 +37,7 @@ class StringOptionsField(
 
     override fun readFrom(component: Any) {
         when (component) {
-            is Element -> value = ElementUtils.readString(component, this.field) ?: this.default
+            is Element -> value = ElementUtils.readString(component, name = this.field) ?: this.default
             is EditorTextField -> value = component.text
             is JComboBox<*> -> value = component.selectedItem.toString()
             is PublicStringAddEditDeleteListPanel -> value = component.listItems.joinToString(",")

--- a/src/main/kotlin/com/emberjs/configuration/serve/EmberServeConfiguration.kt
+++ b/src/main/kotlin/com/emberjs/configuration/serve/EmberServeConfiguration.kt
@@ -21,7 +21,7 @@ class EmberServeConfiguration(project: Project, factory: ConfigurationFactory, n
 
     @NotNull
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
-        return EmberServeSettingsEditor()
+        return EmberServeSettingsEditor(project)
     }
 
     @Nullable

--- a/src/main/kotlin/com/emberjs/configuration/serve/ui/EmberServeSettingsEditor.form
+++ b/src/main/kotlin/com/emberjs/configuration/serve/ui/EmberServeSettingsEditor.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="659" height="493"/>
+      <xy x="20" y="20" width="659" height="463"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -325,7 +325,7 @@
           </component>
         </children>
       </grid>
-      <grid id="12771" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="12771" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -343,12 +343,27 @@
           </component>
           <component id="e1099" class="com.intellij.application.options.ModulesComboBox" binding="myModulesComboBox">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="0" indent="0" use-parent-layout="false">
-                <preferred-size width="59" height="30"/>
-              </grid>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
+          <component id="519e" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="com/emberjs/locale/EmberServeConfigurationEditor" key="node.interpreter"/>
+            </properties>
+          </component>
+          <grid id="4ad5a" binding="myNodeSettingsPanel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children/>
+          </grid>
         </children>
       </grid>
     </children>

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfiguration.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfiguration.kt
@@ -17,7 +17,7 @@ class EmberTestConfiguration(project: Project, factory: ConfigurationFactory, na
 
     @NotNull
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
-        return EmberTestSettingsEditor()
+        return EmberTestSettingsEditor(project)
     }
 
     @Nullable

--- a/src/main/kotlin/com/emberjs/configuration/test/ui/EmberTestSettingsEditor.form
+++ b/src/main/kotlin/com/emberjs/configuration/test/ui/EmberTestSettingsEditor.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="560" height="688"/>
+      <xy x="20" y="20" width="560" height="641"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -327,7 +327,7 @@
           </grid>
         </children>
       </grid>
-      <grid id="74127" layout-manager="GridLayoutManager" row-count="1" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="74127" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
@@ -345,15 +345,27 @@
           </component>
           <component id="e1100" class="com.intellij.application.options.ModulesComboBox" binding="myModulesComboBox">
             <constraints>
-              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
           </component>
-          <hspacer id="d6cb0">
+          <component id="ebaf7" class="javax.swing.JLabel">
             <constraints>
-              <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
             </constraints>
-          </hspacer>
+            <properties>
+              <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="node.interpreter"/>
+            </properties>
+          </component>
+          <grid id="f4e" binding="myNodeSettingsPanel" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="1" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children/>
+          </grid>
         </children>
       </grid>
     </children>

--- a/src/main/kotlin/com/emberjs/configuration/utils/ElementUtils.kt
+++ b/src/main/kotlin/com/emberjs/configuration/utils/ElementUtils.kt
@@ -7,27 +7,43 @@ import org.jdom.Element
 
 class ElementUtils {
     companion object {
-        fun writeString(element: Element, name: String, value: String, elementName: String = "option") {
+        fun writeString(element: Element, elementName: String = "option", value: Any, name: String? = null) {
             val opt = org.jdom.Element(elementName)
-            opt.setAttribute("name", name)
-            opt.setAttribute("value", value)
+            if (name != null) {
+                opt.setAttribute("name", name)
+            }
+            opt.setAttribute("value", value.toString())
             element.addContent(opt)
         }
 
-        fun readString(element: Element, name: String, elementName: String = "option"): String? =
-                element.children
-                        .find { it.name == elementName && it.getAttributeValue("name") == name }
-                        ?.getAttributeValue("value")
+        fun readString(element: Element, elementName: String = "option", name: String? = null): String? {
+            return element.children
+                    .find {
+                        var matches = it.name == elementName
+                        if (name != null) {
+                            matches = matches && it.getAttributeValue("name") == name
+                        }
+                        matches
+                    }
+                    ?.getAttributeValue("value")
 
-        fun writeBool(element: Element, name: String, value: Boolean, elementName: String = "option") {
-            writeString(element, name, value.toString(), elementName)
         }
 
-        fun readBool(element: Element, name: String, elementName: String = "option") = readString(element, name, elementName)?.toBoolean()
+        fun writeBool(element: Element, elementName: String = "option", value: Boolean, name: String? = null) {
+            writeString(element, elementName, value.toString(), name)
+        }
 
-        fun removeField(element: Element, name: String, elementName: String = "option") {
+        fun readBool(element: Element, elementName: String = "option", name: String? = null) = readString(element, elementName, name)?.toBoolean()
+
+        fun removeField(element: Element, elementName: String = "option", name: String? = null) {
             element.children
-                    .find { it.name == elementName && it.getAttributeValue("name") == name }
+                    .find {
+                        var matches = it.name == elementName
+                        if (name != null) {
+                            matches = matches && it.getAttributeValue("name") == name
+                        }
+                        matches
+                    }
                     ?.let { it.parent.removeContent(it) }
         }
     }

--- a/src/main/resources/com/emberjs/locale/EmberServeConfigurationEditor.properties
+++ b/src/main/resources/com/emberjs/locale/EmberServeConfigurationEditor.properties
@@ -27,3 +27,5 @@ proxy.secureProxy=Secure proxy:
 proxy.transparentProxy=Transparent proxy:
 
 configuration.title=Serve configuration:
+
+node.interpreter=Node interpreter:

--- a/src/main/resources/com/emberjs/locale/EmberTestConfigurationEditor.properties
+++ b/src/main/resources/com/emberjs/locale/EmberTestConfigurationEditor.properties
@@ -28,3 +28,5 @@ filter.option.module=Module
 filter.option.filter=Filter
 
 configuration.title=Test configuration:
+
+node.interpreter=Node interpreter:


### PR DESCRIPTION
This adds configuration for the `<node-interpreter value="project" />`
workspace element

fixes #241