### PR TITLE
feat: expose field to configure run configuration environment

### DIFF
--- a/src/main/kotlin/com/emberjs/cli/EmberCli.kt
+++ b/src/main/kotlin/com/emberjs/cli/EmberCli.kt
@@ -11,6 +11,7 @@ class EmberCli(val project: Project, vararg val parameters: String) {
 
     var workDirectory: String? = null
     var nodeInterpreter: String? = null
+    var env: Map<String, String>? = null
 
     private fun nodeCommandLine(): GeneralCommandLine {
         val interpreterRef = NodeJsInterpreterRef.create(nodeInterpreter)
@@ -39,6 +40,9 @@ class EmberCli(val project: Project, vararg val parameters: String) {
         }
 
         return commandLine.also {
+            if (env != null) {
+                it.withEnvironment(env)
+            }
             it.addParameters(*parameters)
             it.withWorkDirectory(workDirectory)
         }

--- a/src/main/kotlin/com/emberjs/configuration/EmberCommandLineState.kt
+++ b/src/main/kotlin/com/emberjs/configuration/EmberCommandLineState.kt
@@ -16,15 +16,16 @@ open class EmberCommandLineState(environment: ExecutionEnvironment) : CommandLin
         val argList = configuration.options.toCommandLineOptions()
 
         val workingDirectory =
-                // if module configured, use that as workDirectory
-                configuration.module?.moduleFile?.parentModule?.path ?:
-                environment.dataContext?.getData(LangDataKeys.MODULE)?.emberRoot?.path ?:
-                environment.project.basePath
+        // if module configured, use that as workDirectory
+                configuration.module?.moduleFile?.parentModule?.path
+                        ?: environment.dataContext?.getData(LangDataKeys.MODULE)?.emberRoot?.path
+                        ?: environment.project.basePath
 
         val cmd = EmberCli(environment.project, configuration.command, *argList)
                 .apply {
                     workDirectory = workingDirectory
                     nodeInterpreter = configuration.nodeInterpreter
+                    env = configuration.env
                 }
                 .commandLine()
                 .apply {

--- a/src/main/kotlin/com/emberjs/configuration/EmberConfiguration.kt
+++ b/src/main/kotlin/com/emberjs/configuration/EmberConfiguration.kt
@@ -7,4 +7,5 @@ interface EmberConfiguration {
     val options: EmberOptions
     var module: Module?
     var nodeInterpreter: String?
+    var env: Map<String, String>?
 }

--- a/src/main/kotlin/com/emberjs/configuration/EmberConfigurationBase.kt
+++ b/src/main/kotlin/com/emberjs/configuration/EmberConfigurationBase.kt
@@ -13,6 +13,7 @@ abstract class EmberConfigurationBase(project: Project, factory: ConfigurationFa
         EmberConfiguration {
     override var module: Module? = null
     override var nodeInterpreter: String? = null
+    override var env: Map<String, String>? = null
 
     override fun writeExternal(element: Element) {
         super.writeExternal(element)
@@ -30,6 +31,11 @@ abstract class EmberConfigurationBase(project: Project, factory: ConfigurationFa
             is String -> ElementUtils.writeString(element, "node-interpreter", nodeInterpreter!!)
             else -> ElementUtils.removeField(element, "node-interpreter")
         }
+
+        when (env) {
+            is Map -> ElementUtils.writeEnv(element, env!!)
+            else -> ElementUtils.removeEnv(element)
+        }
     }
 
     override fun readExternal(element: Element) {
@@ -44,6 +50,7 @@ abstract class EmberConfigurationBase(project: Project, factory: ConfigurationFa
         ElementUtils.readString(element, "node-interpreter")?.let { elementNodeInterpreter ->
             nodeInterpreter = elementNodeInterpreter
         }
+        ElementUtils.readEnv(element)?.let { env = it }
     }
 
 }

--- a/src/main/kotlin/com/emberjs/configuration/OptionsField.kt
+++ b/src/main/kotlin/com/emberjs/configuration/OptionsField.kt
@@ -5,7 +5,7 @@ abstract class OptionsField<T>(
         val field: String,
         val cmdlineOptionName: String
 ) {
-    abstract var value : T
+    abstract var value: T
 
     abstract fun writeTo(component: Any)
     abstract fun readFrom(component: Any)

--- a/src/main/kotlin/com/emberjs/configuration/serve/ui/EmberServeSettingsEditor.form
+++ b/src/main/kotlin/com/emberjs/configuration/serve/ui/EmberServeSettingsEditor.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="659" height="463"/>
+      <xy x="20" y="20" width="659" height="498"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -325,7 +325,7 @@
           </component>
         </children>
       </grid>
-      <grid id="12771" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="12771" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -364,6 +364,20 @@
             <border type="none"/>
             <children/>
           </grid>
+          <component id="700f8" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="com/emberjs/locale/EmberServeConfigurationEditor" key="environment.variables"/>
+            </properties>
+          </component>
+          <component id="20402" class="com.intellij.execution.configuration.EnvironmentVariablesTextFieldWithBrowseButton" binding="myEnvVars">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
         </children>
       </grid>
     </children>

--- a/src/main/kotlin/com/emberjs/configuration/serve/ui/EmberServeSettingsEditor.kt
+++ b/src/main/kotlin/com/emberjs/configuration/serve/ui/EmberServeSettingsEditor.kt
@@ -4,6 +4,7 @@ import com.emberjs.configuration.serve.EmberServeConfiguration
 import com.emberjs.configuration.serve.EmberServeOptions
 import com.emberjs.project.EmberModuleType
 import com.intellij.application.options.ModulesComboBox
+import com.intellij.execution.configuration.EnvironmentVariablesTextFieldWithBrowseButton
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterField
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterRef
 import com.intellij.openapi.options.SettingsEditor
@@ -47,6 +48,7 @@ class EmberServeSettingsEditor(
     private var myModulesComboBox: ModulesComboBox? = null
     private var myNodeSettingsPanel: JPanel? = null
     private var myNodeInterpreterField: NodeJsInterpreterField? = null
+    private var myEnvVars: EnvironmentVariablesTextFieldWithBrowseButton? = null
 
     private val bundle: ResourceBundle = ResourceBundle.getBundle("com.emberjs.locale.EmberServeConfigurationEditor")
 
@@ -88,6 +90,10 @@ class EmberServeSettingsEditor(
             is String -> NodeJsInterpreterRef.create(configuration.nodeInterpreter)
             else -> NodeJsInterpreterRef.createProjectRef()
         }
+
+        configuration.env?.let {
+            myEnvVars?.envs = it
+        }
     }
 
     override fun applyEditorTo(configuration: EmberServeConfiguration) {
@@ -96,6 +102,7 @@ class EmberServeSettingsEditor(
         }
         configuration.module = myModulesComboBox?.selectedModule
         configuration.nodeInterpreter = myNodeInterpreterField?.interpreterRef?.referenceName
+        configuration.env = myEnvVars?.envs
     }
 
     @NotNull

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestCommandLineState.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestCommandLineState.kt
@@ -9,8 +9,8 @@ import com.intellij.execution.configurations.RunConfiguration
 import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.runners.ProgramRunner
-import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil
 import com.intellij.execution.testframework.autotest.ToggleAutoTestAction
+import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil
 import com.intellij.execution.testframework.sm.SMTestRunnerConnectionUtil.createAndAttachConsole
 
 class EmberTestCommandLineState(environment: ExecutionEnvironment) : EmberCommandLineState(environment) {

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfiguration.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfiguration.kt
@@ -4,7 +4,9 @@ import com.emberjs.configuration.EmberConfigurationBase
 import com.emberjs.configuration.test.ui.EmberTestSettingsEditor
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.Executor
-import com.intellij.execution.configurations.*
+import com.intellij.execution.configurations.ConfigurationFactory
+import com.intellij.execution.configurations.RunConfiguration
+import com.intellij.execution.configurations.RunProfileState
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestOptions.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestOptions.kt
@@ -60,17 +60,17 @@ class EmberTestOptions : EmberOptions {
                 .filter {
                     // allow any fields that aren't LAUNCH, FILTER, MODULE
                     !arrayOf("LAUNCH", "FILTER", "MODULE").contains(it.field) ||
-                    // allow any LAUNCH if LAUNCH_OPTION is CUSTOM
-                    it.field == "LAUNCH" && launchOption.value == LaunchType.CUSTOM.value ||
-                    // allow any FILTER if FILTER_OPTION is FILTER
-                    it.field =="FILTER" && filterOption.value == FilterType.FILTER.value ||
-                    // allow any MODULE if FILTER_OPTION is MODULE
-                    it.field =="MODULE" && filterOption.value == FilterType.MODULE.value
+                            // allow any LAUNCH if LAUNCH_OPTION is CUSTOM
+                            it.field == "LAUNCH" && launchOption.value == LaunchType.CUSTOM.value ||
+                            // allow any FILTER if FILTER_OPTION is FILTER
+                            it.field == "FILTER" && filterOption.value == FilterType.FILTER.value ||
+                            // allow any MODULE if FILTER_OPTION is MODULE
+                            it.field == "MODULE" && filterOption.value == FilterType.MODULE.value
                 }
                 .filter { optionsField ->
                     optionsField.cmdlineOptionName.isNotEmpty() &&
-                    optionsField.value != optionsField.default &&
-                    optionsField.value.toString().isNotEmpty()
+                            optionsField.value != optionsField.default &&
+                            optionsField.value.toString().isNotEmpty()
                 }
                 .map { "--${it.cmdlineOptionName}=${it.value}" }
                 .toTypedArray()

--- a/src/main/kotlin/com/emberjs/configuration/test/ui/EmberTestSettingsEditor.form
+++ b/src/main/kotlin/com/emberjs/configuration/test/ui/EmberTestSettingsEditor.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="myPanel" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="560" height="641"/>
+      <xy x="20" y="20" width="560" height="676"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -327,7 +327,7 @@
           </grid>
         </children>
       </grid>
-      <grid id="74127" layout-manager="GridLayoutManager" row-count="2" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="74127" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
@@ -366,6 +366,20 @@
             <border type="none"/>
             <children/>
           </grid>
+          <component id="5eca9" class="javax.swing.JLabel">
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text resource-bundle="com/emberjs/locale/EmberTestConfigurationEditor" key="environment.variables"/>
+            </properties>
+          </component>
+          <component id="a02b3" class="com.intellij.execution.configuration.EnvironmentVariablesTextFieldWithBrowseButton" binding="myEnvVars">
+            <constraints>
+              <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+          </component>
         </children>
       </grid>
     </children>

--- a/src/main/kotlin/com/emberjs/configuration/test/ui/EmberTestSettingsEditor.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/ui/EmberTestSettingsEditor.kt
@@ -7,6 +7,7 @@ import com.emberjs.configuration.test.LaunchType
 import com.emberjs.configuration.utils.PublicStringAddEditDeleteListPanel
 import com.emberjs.project.EmberModuleType
 import com.intellij.application.options.ModulesComboBox
+import com.intellij.execution.configuration.EnvironmentVariablesTextFieldWithBrowseButton
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterField
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterRef
 import com.intellij.openapi.options.ConfigurationException
@@ -62,6 +63,7 @@ class EmberTestSettingsEditor(
     private var myModulesComboBox: ModulesComboBox? = null
     private var myNodeSettingsPanel: JPanel? = null
     private var myNodeInterpreterField: NodeJsInterpreterField? = null
+    private var myEnvVars: EnvironmentVariablesTextFieldWithBrowseButton? = null
 
     val bundle: ResourceBundle = ResourceBundle.getBundle("com.emberjs.locale.EmberTestConfigurationEditor")
     val launchers: MutableList<String> = mutableListOf()
@@ -128,6 +130,10 @@ class EmberTestSettingsEditor(
             is String -> NodeJsInterpreterRef.create(configuration.nodeInterpreter)
             else -> NodeJsInterpreterRef.createProjectRef()
         }
+
+        configuration.env?.let {
+            myEnvVars?.envs = it
+        }
     }
 
     @Throws(ConfigurationException::class)
@@ -138,6 +144,7 @@ class EmberTestSettingsEditor(
 
         configuration.module = myModulesComboBox?.selectedModule
         configuration.nodeInterpreter = myNodeInterpreterField?.interpreterRef?.referenceName
+        configuration.env = myEnvVars?.envs
     }
 
     @NotNull

--- a/src/main/kotlin/com/emberjs/configuration/utils/ElementUtils.kt
+++ b/src/main/kotlin/com/emberjs/configuration/utils/ElementUtils.kt
@@ -46,5 +46,49 @@ class ElementUtils {
                     }
                     ?.let { it.parent.removeContent(it) }
         }
+
+        /**
+         * ENV uses the following structure:
+         * <envs>
+         *   <env name="FOO" value="BAR" />
+         * </envs>
+         */
+        fun readEnv(element: Element): Map<String, String>? {
+            val env = mutableMapOf<String, String>()
+            val envs = element.children
+                    .find { it.name === "envs" } ?: return null
+
+            envs.let {
+                it.children
+                        .filter { it.name === "env" }
+                        .forEach {
+                            env[it.getAttributeValue("name")] = it.getAttributeValue("value")
+                        }
+            }
+
+            return env;
+        }
+
+        fun removeEnv(element: Element) {
+            element.children
+                    .find { it.name === "envs" }
+                    ?.let { it.parentElement.removeContent(it) }
+        }
+
+        fun writeEnv(element: Element, map: Map<String, String>) {
+            val envs = org.jdom.Element("envs")
+
+            // do nothing if map is empty
+            if (map.size == 0) return
+
+            map.forEach {
+                val env = org.jdom.Element("env")
+                env.setAttribute("name", it.key)
+                env.setAttribute("value", it.value)
+                envs.addContent(env)
+            }
+
+            element.addContent(envs)
+        }
     }
 }

--- a/src/main/resources/com/emberjs/locale/EmberServeConfigurationEditor.properties
+++ b/src/main/resources/com/emberjs/locale/EmberServeConfigurationEditor.properties
@@ -29,3 +29,4 @@ proxy.transparentProxy=Transparent proxy:
 configuration.title=Serve configuration:
 
 node.interpreter=Node interpreter:
+environment.variables=Environment variables:

--- a/src/main/resources/com/emberjs/locale/EmberTestConfigurationEditor.properties
+++ b/src/main/resources/com/emberjs/locale/EmberTestConfigurationEditor.properties
@@ -30,3 +30,4 @@ filter.option.filter=Filter
 configuration.title=Test configuration:
 
 node.interpreter=Node interpreter:
+environment.variables=Environment variables:


### PR DESCRIPTION
This uses the same workspace.xml serialization format that any of the node run configuration use:

```xml
<envs>
  <env name="FOO" value="BAR" />
</envs>
```

fixes #253