### PR TITLE
CI: Use `openjdk8` instead of `oraclejdk8`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
-jdk:
-  - oraclejdk8
+jdk: openjdk8
 
 before_deploy:
   - ./gradlew buildPlugin


### PR DESCRIPTION
`oraclejdk8` won't install reliably anymore due to a change on the Oracle servers

see https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038