### PR TITLE
Replace the deprecated `LightPlatformCodeInsightFixtureTestCase` with `BasePlatformTestCase`

### DIFF
--- a/src/test/kotlin/com/emberjs/hbs/HbsPatternsTest.kt
+++ b/src/test/kotlin/com/emberjs/hbs/HbsPatternsTest.kt
@@ -6,10 +6,10 @@ import com.emberjs.hbs.HbsPatterns.SIMPLE_MUSTACHE_NAME_ID
 import com.emberjs.hbs.HbsPatterns.SUB_EXPR_NAME_ID
 import com.intellij.patterns.PsiElementPattern
 import com.intellij.psi.PsiElement
-import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import org.assertj.core.api.Assertions.assertThat
 
-class HbsPatternsTest : LightPlatformCodeInsightFixtureTestCase() {
+class HbsPatternsTest : BasePlatformTestCase() {
     fun testSimpleMustache() = with(SIMPLE_MUSTACHE_NAME_ID) {
         test("{{foo<caret>}}")
         test("{{fo<caret>o}}")

--- a/src/test/kotlin/com/emberjs/index/EmberNameIndexTest.kt
+++ b/src/test/kotlin/com/emberjs/index/EmberNameIndexTest.kt
@@ -1,12 +1,12 @@
 package com.emberjs.index
 
 import com.emberjs.resolver.EmberName
-import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.indexing.FileBasedIndex
 import org.assertj.core.api.Assertions.assertThat
 import java.nio.file.Paths
 
-class EmberNameIndexTest : LightPlatformCodeInsightFixtureTestCase() {
+class EmberNameIndexTest : BasePlatformTestCase() {
     override fun getTestDataPath(): String? {
         val resource = ClassLoader.getSystemResource("com/emberjs/index/fixtures")
         return Paths.get(resource.toURI()).toAbsolutePath().toString()

--- a/src/test/kotlin/com/emberjs/navigation/EmberGotoRelatedProviderTest.kt
+++ b/src/test/kotlin/com/emberjs/navigation/EmberGotoRelatedProviderTest.kt
@@ -3,12 +3,12 @@ package com.emberjs.navigation
 import com.emberjs.EmberTestFixtures.FIXTURES_PATH
 import com.emberjs.index.EmberNameIndex
 import com.emberjs.utils.use
-import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.indexing.FileBasedIndex
 import org.assertj.core.api.SoftAssertions
 import org.junit.Test
 
-class EmberGotoRelatedProviderTest : LightPlatformCodeInsightFixtureTestCase() {
+class EmberGotoRelatedProviderTest : BasePlatformTestCase() {
 
     val provider = EmberGotoRelatedProvider()
 

--- a/src/test/kotlin/com/emberjs/navigation/EmberTestFinderTest.kt
+++ b/src/test/kotlin/com/emberjs/navigation/EmberTestFinderTest.kt
@@ -5,13 +5,13 @@ import com.emberjs.index.EmberNameIndex
 import com.emberjs.resolver.EmberName
 import com.emberjs.utils.use
 import com.intellij.psi.PsiManager
-import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.indexing.FileBasedIndex
 import org.assertj.core.api.Assertions
 import org.assertj.core.api.SoftAssertions
 import org.junit.Test
 
-class EmberTestFinderTest : LightPlatformCodeInsightFixtureTestCase() {
+class EmberTestFinderTest : BasePlatformTestCase() {
 
     val finder = EmberTestFinder()
 

--- a/src/test/kotlin/com/emberjs/translations/EmberI18nFoldingBuilderTest.kt
+++ b/src/test/kotlin/com/emberjs/translations/EmberI18nFoldingBuilderTest.kt
@@ -1,10 +1,10 @@
 package com.emberjs.translations
 
-import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.indexing.FileBasedIndex
 import java.nio.file.Paths
 
-class EmberI18nFoldingBuilderTest : LightPlatformCodeInsightFixtureTestCase() {
+class EmberI18nFoldingBuilderTest : BasePlatformTestCase() {
 
     override fun getTestDataPath(): String? {
         val resource = ClassLoader.getSystemResource("com/emberjs/translations/fixtures")

--- a/src/test/kotlin/com/emberjs/translations/EmberI18nIndexTest.kt
+++ b/src/test/kotlin/com/emberjs/translations/EmberI18nIndexTest.kt
@@ -1,12 +1,12 @@
 package com.emberjs.translations
 
-import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.indexing.FileBasedIndex
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
 import java.nio.file.Paths
 
-class EmberI18nIndexTest : LightPlatformCodeInsightFixtureTestCase() {
+class EmberI18nIndexTest : BasePlatformTestCase() {
 
     fun testSimpleKey() = doTest("foo", mapOf("en" to "bar baz", "de" to "Bar Baz"))
     fun testDottedKey() = doTest("user.edit.title", mapOf("en" to "Edit User", "de" to "Benutzer editieren"))

--- a/src/test/kotlin/com/emberjs/translations/EmberI18nTest.kt
+++ b/src/test/kotlin/com/emberjs/translations/EmberI18nTest.kt
@@ -1,11 +1,11 @@
 package com.emberjs.translations
 
-import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.indexing.FileBasedIndex
 import org.assertj.core.api.Assertions.assertThat
 import java.nio.file.Paths
 
-class EmberI18nTest : LightPlatformCodeInsightFixtureTestCase() {
+class EmberI18nTest : BasePlatformTestCase() {
 
     override fun getTestDataPath(): String? {
         val resource = ClassLoader.getSystemResource("com/emberjs/translations/fixtures")

--- a/src/test/kotlin/com/emberjs/translations/EmberIntlFoldingBuilderTest.kt
+++ b/src/test/kotlin/com/emberjs/translations/EmberIntlFoldingBuilderTest.kt
@@ -1,10 +1,10 @@
 package com.emberjs.translations
 
-import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.indexing.FileBasedIndex
 import java.nio.file.Paths
 
-class EmberIntlFoldingBuilderTest : LightPlatformCodeInsightFixtureTestCase() {
+class EmberIntlFoldingBuilderTest : BasePlatformTestCase() {
 
     override fun getTestDataPath(): String? {
         val resource = ClassLoader.getSystemResource("com/emberjs/translations/fixtures")

--- a/src/test/kotlin/com/emberjs/translations/EmberIntlIndexTest.kt
+++ b/src/test/kotlin/com/emberjs/translations/EmberIntlIndexTest.kt
@@ -1,12 +1,12 @@
 package com.emberjs.translations
 
-import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.indexing.FileBasedIndex
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
 import java.nio.file.Paths
 
-class EmberIntlIndexTest : LightPlatformCodeInsightFixtureTestCase() {
+class EmberIntlIndexTest : BasePlatformTestCase() {
 
     fun testSimple() = doTest("foo", mapOf("en" to "bar baz", "de" to "Bar Baz"))
     fun testPlaceholder() = doTest("long-string", mapOf("en" to "Something veeeeery long with a {placeholder}"))

--- a/src/test/kotlin/com/emberjs/translations/EmberIntlTest.kt
+++ b/src/test/kotlin/com/emberjs/translations/EmberIntlTest.kt
@@ -1,11 +1,11 @@
 package com.emberjs.translations
 
-import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.indexing.FileBasedIndex
 import org.assertj.core.api.Assertions.assertThat
 import java.nio.file.Paths
 
-class EmberIntlTest : LightPlatformCodeInsightFixtureTestCase() {
+class EmberIntlTest : BasePlatformTestCase() {
 
     override fun getTestDataPath(): String? {
         val resource = ClassLoader.getSystemResource("com/emberjs/translations/fixtures")

--- a/src/test/kotlin/com/emberjs/translations/EmberTranslationHbsReferenceTest.kt
+++ b/src/test/kotlin/com/emberjs/translations/EmberTranslationHbsReferenceTest.kt
@@ -1,12 +1,12 @@
 package com.emberjs.translations
 
 import com.dmarcotte.handlebars.file.HbFileType
-import com.intellij.testFramework.fixtures.LightPlatformCodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.indexing.FileBasedIndex
 import org.assertj.core.api.Assertions.assertThat
 import java.nio.file.Paths
 
-class EmberTranslationHbsReferenceTest : LightPlatformCodeInsightFixtureTestCase() {
+class EmberTranslationHbsReferenceTest : BasePlatformTestCase() {
 
     override fun getTestDataPath(): String? {
         val resource = ClassLoader.getSystemResource("com/emberjs/translations/fixtures")


### PR DESCRIPTION
This should get rid of a few deprecation warnings 🎉 