### PR TITLE
Use `kotlin-stdlib-jdk8` dependency instead of `kotlin-stdlib`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     testCompile "org.assertj:assertj-core:3.14.0"
 }
 


### PR DESCRIPTION
to avoid the following error:

```
[0]: java.lang.NoClassDefFoundError: kotlin/jdk7/AutoCloseableKt
[1]: java.lang.NoClassDefFoundError: Could not initialize class com.intellij.openapi.vfs.newvfs.ManagingFS$ManagingFSHolder
[2]: java.lang.NoClassDefFoundError: kotlin/jdk7/AutoCloseableKt
```