### PR TITLE
fix: ensure that we implement `executable(pkg: NodePage)` as the old impl was deprecated

### DIFF
--- a/src/main/kotlin/com/emberjs/cli/EmberCliProjectGenerator.kt
+++ b/src/main/kotlin/com/emberjs/cli/EmberCliProjectGenerator.kt
@@ -1,12 +1,11 @@
 package com.emberjs.cli
 
 import com.emberjs.icons.EmberIcons
-import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreter
+import com.intellij.javascript.nodejs.util.NodePackage
 import com.intellij.lang.javascript.boilerplate.NpmPackageProjectGenerator
 import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ContentEntry
-import com.intellij.openapi.util.Pair
 import com.intellij.openapi.vfs.VirtualFile
 import org.intellij.lang.annotations.Language
 import java.io.File
@@ -23,7 +22,11 @@ open class EmberCliProjectGenerator : NpmPackageProjectGenerator() {
     override fun packageName() = "ember-cli"
     override fun presentablePackageName() = "Ember &CLI:"
 
-    override fun executable(path: String) = Companion.executable(path)
+    override fun executable(pkg: NodePackage): String {
+        return pkg.findBinFile("ember", "bin${File.separator}ember")?.path
+                ?: "${pkg.systemDependentPath}${File.separator}bin${File.separator}ember"
+    }
+
     override fun generatorArgs(project: Project, baseDir: VirtualFile) = arrayOf("init", "--name=${baseDir.name}")
 
     override fun filters(project: Project, baseDir: VirtualFile) = arrayOf(EmberCliFilter(project, baseDir.path))
@@ -33,9 +36,5 @@ open class EmberCliProjectGenerator : NpmPackageProjectGenerator() {
     override fun generateProject(project: Project, baseDir: VirtualFile, settings: NpmPackageProjectGenerator.Settings, module: Module) {
         EmberCliProjectConfigurator.setupEmber(project, module, baseDir)
         super.generateProject(project, baseDir, settings, module)
-    }
-
-    companion object {
-        fun executable(path: String) = "$path${File.separator}bin${File.separator}ember"
     }
 }


### PR DESCRIPTION
Seems like JB deprecated the `executable(string)` call ago and broke it.

Before this change:
```
/usr/bin/node "" init --name=<name>
```

With this change:
```
/usr/bin/node /path/to/npm/lib/node_modules/ember-cli/bin/ember init --name=<name>
```