### PR TITLE
Ignore template-lint parsing errors

### DIFF
--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintResultParser.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintResultParser.kt
@@ -48,6 +48,10 @@ class TemplateLintResultParser {
             val issues = obj.getJSONArray(obj.keys().next() as String)
             for (i in 0 until issues.length()) {
                 val issue = issues.getJSONObject(i)
+
+                // we skip fatal errors
+                if (issue.has("fatal") && issue.getBoolean("fatal")) continue
+
                 errorList.add(parseItem(issue))
             }
 


### PR DESCRIPTION
This relies on template-lint [marking errors as fatal](https://github.com/ember-template-lint/ember-template-lint/issues/203) which we can (probably) ignore.

fixes #300