### PR TITLE
Update to IntelliJ 2020.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,10 @@ buildscript {
 
         // see https://www.jetbrains.com/intellij-repository/releases/
         // and https://www.jetbrains.com/intellij-repository/snapshots/
-        intellijVersion = '193.5233.102'
+        intellijVersion = '2020.1'
 
         // see https://plugins.jetbrains.com/plugin/6884-handlebars-mustache/versions
-        handlebarsPluginVersion = '193.5233.116'
+        handlebarsPluginVersion = '201.6668.121'
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,13 @@ intellij {
     downloadSources !System.getenv().containsKey('CI')
 
     pluginName = 'Ember.js'
-    plugins = ['JavaScriptLanguage', 'CSS', 'yaml', "com.dmarcotte.handlebars:$handlebarsPluginVersion"]
+    plugins = [
+        'JavaScriptLanguage',
+        'CSS',
+        'platform-images',
+        'yaml',
+        "com.dmarcotte.handlebars:$handlebarsPluginVersion",
+    ]
 
     sandboxDirectory = project.rootDir.canonicalPath + "/.sandbox"
 

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintPackage.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintPackage.kt
@@ -21,7 +21,7 @@ class TemplateLintPackage(
     @Throws(ExecutionException::class)
     fun addMainEntryJsFile(commandLine: GeneralCommandLine, interpreter: NodeJsInterpreter) {
         if (myPkg is YarnPnpNodePackage) {
-            myPkg.addYarnRunToCommandLine(commandLine, myProject, interpreter)
+            myPkg.addYarnRunToCommandLine(commandLine, myProject, interpreter, TemplateLintUtil.PACKAGE_NAME)
         } else {
             val file = myPkg.findBinFile(TemplateLintUtil.PACKAGE_NAME, "dist${File.separator}cli.js")
                     ?: throw ExecutionException("Please specify TemplateLint package correctly: ${TemplateLintUtil.PACKAGE_NAME} binary not found")


### PR DESCRIPTION
This PR is updating the plugin to support IntelliJ 2020.1

Resolves #309 

Unfortunately, a few of our tests are currently failing due to several `FileBasedIndex.getInstance().requestRebuild()` calls in the tests that are now causing `NullPointerExceptions`.

@denofevil any clues on how to fix the testing code? 🙏 