### PR TITLE
Add support for CSS modules in "Goto Related" dialog

### DIFF
--- a/src/main/kotlin/com/emberjs/index/EmberNameIndex.kt
+++ b/src/main/kotlin/com/emberjs/index/EmberNameIndex.kt
@@ -25,7 +25,7 @@ class EmberNameIndex() : ScalarIndexExtension<EmberName>() {
 
     companion object {
         val NAME: ID<EmberName, Void> = ID.create("ember.names")
-        private val FILE_EXTENSIONS = setOf("js", "ts", "hbs", "handlebars")
+        private val FILE_EXTENSIONS = setOf("css", "scss", "js", "ts", "hbs", "handlebars")
 
         private val index by lazy { FileBasedIndex.getInstance() }
 

--- a/src/main/kotlin/com/emberjs/navigation/EmberGotoRelatedProvider.kt
+++ b/src/main/kotlin/com/emberjs/navigation/EmberGotoRelatedProvider.kt
@@ -29,10 +29,22 @@ class EmberGotoRelatedProvider : GotoRelatedProvider() {
 
         val modulesToSearch = when {
             name.type == "template" && name.name.startsWith("components/") ->
-                listOf(EmberName("component", name.name.removePrefix("components/")))
+                listOf(
+                        EmberName("component", name.name.removePrefix("components/")),
+                        EmberName("styles", name.name)
+                )
+
+            name.type == "styles" && name.name.startsWith("components/") ->
+                listOf(
+                        EmberName("component", name.name.removePrefix("components/")),
+                        EmberName("template", name.name)
+                )
 
             name.type == "component" ->
-                listOf(EmberName("template", "components/${name.name}"))
+                listOf(
+                        EmberName("styles", "components/${name.name}"),
+                        EmberName("template", "components/${name.name}")
+                )
 
             else -> RELATED_TYPES[name.type].orEmpty().map { EmberName(it, name.name) }
         }
@@ -45,9 +57,10 @@ class EmberGotoRelatedProvider : GotoRelatedProvider() {
 
     companion object {
         val RELATED_TYPES = mapOf(
-                "controller" to listOf("route", "template"),
-                "route" to listOf("controller", "template"),
-                "template" to listOf("controller", "route"),
+                "controller" to listOf("route", "styles", "template"),
+                "route" to listOf("controller", "styles", "template"),
+                "styles" to listOf("controller", "route", "template"),
+                "template" to listOf("controller", "route", "styles"),
                 "model" to listOf("adapter", "serializer"),
                 "adapter" to listOf("model", "serializer"),
                 "serializer" to listOf("adapter", "model")

--- a/src/test/kotlin/com/emberjs/navigation/EmberGotoRelatedProviderTest.kt
+++ b/src/test/kotlin/com/emberjs/navigation/EmberGotoRelatedProviderTest.kt
@@ -62,8 +62,20 @@ class EmberGotoRelatedProviderTest : BasePlatformTestCase() {
             "app/user/model.js" to listOf("app/user/adapter.js"),
             "app/pet/serializer.js" to listOf("app/pet/model.js"),
             "app/session/service.js" to listOf(),
-            "app/components/flat-structured-component.js" to listOf("app/components/flat-structured-component.hbs"),
-            "app/components/flat-structured-component.hbs" to listOf("app/components/flat-structured-component.js"),
+            "app/components/flat-structured-component.js" to listOf(
+                    "app/components/flat-structured-component.scss",
+                    "app/components/flat-structured-component.module.css",
+                    "app/components/flat-structured-component.module.scss",
+                    "app/components/flat-structured-component.css",
+                    "app/components/flat-structured-component.hbs"
+            ),
+            "app/components/flat-structured-component.hbs" to listOf(
+                    "app/components/flat-structured-component.scss",
+                    "app/components/flat-structured-component.module.css",
+                    "app/components/flat-structured-component.module.scss",
+                    "app/components/flat-structured-component.css",
+                    "app/components/flat-structured-component.js"
+            ),
             "app/components/test-component-nested/index.js" to listOf("app/components/test-component-nested/index.hbs"),
             "app/components/test-component-nested/index.hbs" to listOf("app/components/test-component-nested/index.js")
     ))

--- a/src/test/kotlin/com/emberjs/resolver/EmberNameTest.kt
+++ b/src/test/kotlin/com/emberjs/resolver/EmberNameTest.kt
@@ -90,6 +90,10 @@ class EmberNameTest {
             "app/application/template.hbs" to "template:application",
             "app/user/adapter.js" to "adapter:user",
             "app/user/model.js" to "model:user",
+            "app/user/styles.css" to "styles:user",
+            "app/user/styles.scss" to "styles:user",
+            "app/user/styles.module.css" to "styles:user",
+            "app/user/styles.module.scss" to "styles:user",
             "foo/controller.js" to null,
             "tests/unit/pet/model-test.js" to "model-test:pet",
             "tests/unit/pet/serializer-test.js" to "serializer-test:pet",
@@ -99,6 +103,12 @@ class EmberNameTest {
             "app/templates/components/blog-post.handlebars" to "template:components/blog-post",
             "app/components/flat-structured-component.js" to "component:flat-structured-component",
             "app/components/flat-structured-component.hbs" to "template:components/flat-structured-component",
+            "app/components/flat-structured-component.scss" to "styles:components/flat-structured-component",
+            "app/components/flat-structured-component.css" to "styles:components/flat-structured-component",
+            "app/components/flat-structured-component.module.scss" to "styles:components/flat-structured-component",
+            "app/components/flat-structured-component.module.css" to "styles:components/flat-structured-component",
+            "app/styles/some-route.css" to "styles:some-route",
+            "app/styles/components/some-component.css" to "styles:components/some-component",
             "app/components/test-component-nested/index.js" to "component:test-component-nested/index",
             "app/components/test-component-nested/index.hbs" to "template:components/test-component-nested/index"
     ))

--- a/src/test/resources/com/emberjs/fixtures/example/app/components/flat-structured-component.css
+++ b/src/test/resources/com/emberjs/fixtures/example/app/components/flat-structured-component.css
@@ -1,0 +1,3 @@
+.foo {
+  margin: 4px;
+}

--- a/src/test/resources/com/emberjs/fixtures/example/app/components/flat-structured-component.module.css
+++ b/src/test/resources/com/emberjs/fixtures/example/app/components/flat-structured-component.module.css
@@ -1,0 +1,3 @@
+.foo {
+  margin: 4px;
+}

--- a/src/test/resources/com/emberjs/fixtures/example/app/components/flat-structured-component.module.scss
+++ b/src/test/resources/com/emberjs/fixtures/example/app/components/flat-structured-component.module.scss
@@ -1,0 +1,3 @@
+.foo {
+  margin: 4px;
+}

--- a/src/test/resources/com/emberjs/fixtures/example/app/components/flat-structured-component.scss
+++ b/src/test/resources/com/emberjs/fixtures/example/app/components/flat-structured-component.scss
@@ -1,0 +1,3 @@
+.foo {
+  margin: 4px;
+}

--- a/src/test/resources/com/emberjs/fixtures/example/app/styles/components/some-component.css
+++ b/src/test/resources/com/emberjs/fixtures/example/app/styles/components/some-component.css
@@ -1,0 +1,3 @@
+.foo {
+  margin: 4px;
+}

--- a/src/test/resources/com/emberjs/fixtures/example/app/styles/some-route.css
+++ b/src/test/resources/com/emberjs/fixtures/example/app/styles/some-route.css
@@ -1,0 +1,3 @@
+.foo {
+  margin: 4px;
+}

--- a/src/test/resources/com/emberjs/fixtures/example/app/user/styles.css
+++ b/src/test/resources/com/emberjs/fixtures/example/app/user/styles.css
@@ -1,0 +1,3 @@
+.foo {
+  margin: 4px;
+}

--- a/src/test/resources/com/emberjs/fixtures/example/app/user/styles.module.css
+++ b/src/test/resources/com/emberjs/fixtures/example/app/user/styles.module.css
@@ -1,0 +1,3 @@
+.foo {
+  margin: 4px;
+}

--- a/src/test/resources/com/emberjs/fixtures/example/app/user/styles.module.scss
+++ b/src/test/resources/com/emberjs/fixtures/example/app/user/styles.module.scss
@@ -1,0 +1,3 @@
+.foo {
+  margin: 4px;
+}

--- a/src/test/resources/com/emberjs/fixtures/example/app/user/styles.scss
+++ b/src/test/resources/com/emberjs/fixtures/example/app/user/styles.scss
@@ -1,0 +1,3 @@
+.foo {
+  margin: 4px;
+}


### PR DESCRIPTION
see https://github.com/salsify/ember-css-modules

Supported file extensions are: `css`, `scss`, `module.css` and `module.scss`