### PR TITLE
TemplateLintResultParser: Fix off-by-one issue

### DIFF
--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintResultParser.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintResultParser.kt
@@ -31,7 +31,7 @@ class TemplateLintResultParser {
                 else -> null
             }
 
-            return JSLinterError(line, column, text, rule, highlightSeverity)
+            return JSLinterError(line, column + 1, text, rule, highlightSeverity)
         }
     }
 


### PR DESCRIPTION
The IntelliJ classes expect the column numbers to be 1-indexed, but we we're giving it 0-indexed column numbers 🙈 