### PR TITLE
include ember addons components & helpers

### DIFF
--- a/src/main/kotlin/com/emberjs/utils/VirtualFileExtensions.kt
+++ b/src/main/kotlin/com/emberjs/utils/VirtualFileExtensions.kt
@@ -1,7 +1,10 @@
 package com.emberjs.utils
 
+import com.google.gson.stream.JsonReader
 import com.intellij.javascript.nodejs.PackageJsonData
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.util.text.CharSequenceReader
+import java.io.IOException
 
 val VirtualFile.parents: Iterable<VirtualFile>
     get() = object : Iterable<VirtualFile> {
@@ -18,9 +21,46 @@ val VirtualFile.parents: Iterable<VirtualFile>
         }
     }
 
+
+val cache = HashMap<String, Boolean>()
+
+val VirtualFile.isEmberAddonFolder: Boolean
+    get() {
+        if (cache.contains(this.path)) return cache.getOrDefault(this.path, false)
+        val packageJsonFile = findFileByRelativePath("package.json") ?: return false
+        var text = ""
+        try {
+            text = String(packageJsonFile.contentsToByteArray())
+            val reader = JsonReader(CharSequenceReader(text))
+            reader.isLenient = true
+            reader.beginObject()
+            while (reader.hasNext()) {
+                val key = reader.nextName()
+                if (key == "keywords") {
+                    reader.beginArray()
+                    while (reader.hasNext()) {
+                        if (reader.nextString() == "ember-addon") {
+                            cache[this.path] = true
+                            return true
+                        }
+                    }
+                    cache[this.path] = false
+                    return false
+                }
+                reader.skipValue()
+            }
+            cache[this.path] = false
+            return false
+        } catch (var3: IOException) {
+            return false
+        }
+    }
+
+
 val VirtualFile.isEmberFolder: Boolean
     get() = findFileByRelativePath("app/app.js") != null ||
-            findFileByRelativePath(".ember-cli") != null
+            findFileByRelativePath(".ember-cli") != null ||
+            findFileByRelativePath(".ember-cli.js") != null
 
 val VirtualFile.isInRepoAddon: Boolean
     get() = findFileByRelativePath("package.json") != null &&
@@ -38,7 +78,7 @@ val VirtualFile.parentModule: VirtualFile?
  * then checks if the package is an Ember CLI project.
  */
 val VirtualFile.parentEmberModule: VirtualFile?
-    get() = this.parentModule?.let { if (it.isEmberFolder || it.isInRepoAddon) it else null }
+    get() = this.parentModule?.let { if (it.isEmberFolder || it.isInRepoAddon || it.isEmberAddonFolder) it else null }
 
 fun findMainPackageJsonFile(file: VirtualFile) = file.parents.asSequence()
         .filter { it.isEmberFolder }

--- a/src/test/kotlin/com/emberjs/EmberTestFixtures.kt
+++ b/src/test/kotlin/com/emberjs/EmberTestFixtures.kt
@@ -27,6 +27,6 @@ object EmberTestFixtures {
             }
         }
 
-        else -> MockVirtualFile(file.name)
+        else -> MockVirtualFile(file.name, file.readText())
     }
 }

--- a/src/test/kotlin/com/emberjs/resolver/EmberNameTest.kt
+++ b/src/test/kotlin/com/emberjs/resolver/EmberNameTest.kt
@@ -4,6 +4,7 @@ import com.emberjs.EmberTestFixtures.APTIBLE
 import com.emberjs.EmberTestFixtures.CRATES_IO
 import com.emberjs.EmberTestFixtures.EXAMPLE
 import com.emberjs.utils.find
+import com.emberjs.utils.parentEmberModule
 import com.emberjs.utils.use
 import com.intellij.openapi.vfs.VirtualFile
 import org.assertj.core.api.Assertions.assertThat
@@ -110,7 +111,8 @@ class EmberNameTest {
             "app/styles/some-route.css" to "styles:some-route",
             "app/styles/components/some-component.css" to "styles:components/some-component",
             "app/components/test-component-nested/index.js" to "component:test-component-nested/index",
-            "app/components/test-component-nested/index.hbs" to "template:components/test-component-nested/index"
+            "app/components/test-component-nested/index.hbs" to "template:components/test-component-nested/index",
+            "node_modules/my-components/addon/components/button/component.js" to "component:button"
     ))
 
     @Test fun testAptible() = doTest(APTIBLE, mapOf(
@@ -138,7 +140,7 @@ class EmberNameTest {
     private fun doTest(root: VirtualFile, tests: Map<String, String?>) {
         SoftAssertions().use {
             for ((path, expectedName) in tests) {
-                assertThat(EmberName.from(root, root.find(path))?.fullName)
+                assertThat(EmberName.from(root.find(path).parentEmberModule!!, root.find(path))?.fullName)
                         .describedAs(path)
                         .apply { if (expectedName == null) isNull() else isEqualTo(expectedName) }
 

--- a/src/test/resources/com/emberjs/fixtures/example/.gitignore
+++ b/src/test/resources/com/emberjs/fixtures/example/.gitignore
@@ -5,7 +5,6 @@
 /tmp
 
 # dependencies
-/node_modules
 /bower_components
 
 # misc

--- a/src/test/resources/com/emberjs/fixtures/example/node_modules/my-components/package.json
+++ b/src/test/resources/com/emberjs/fixtures/example/node_modules/my-components/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "my-components",
+  "version": "0.0.0",
+  "description": "Small description for example goes here",
+  "private": true,
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "ember build",
+    "start": "ember server",
+    "test": "ember test"
+  },
+  "repository": "",
+  "engines": {
+    "node": ">= 0.10.0"
+  },
+  "author": "",
+  "license": "MIT",
+  "ember-addon": {
+    "main": "addon"
+  },
+  "keywords": ["ember-addon"],
+  "devDependencies": {
+  }
+}

--- a/src/test/resources/com/emberjs/fixtures/example/package.json
+++ b/src/test/resources/com/emberjs/fixtures/example/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "my-components": "1.0",
     "ember-cli": "1.13.12",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.5",


### PR DESCRIPTION
this adds autocompletion for components and helpers that are coming from ember addons (in node modules).
It also adds the path to the component in the description. this also might be useful once ember has template imports

it has only been working if the addon also published with .ember-cli file, but thats not always the case nor required.
this change checks the package.json of the module for the keyword "ember-addon" like its done by the ember-cli and then continues to include the components and helpers from that addon into the index.

since the check is done for every file in the addon, i added a cache for improved performance

fixes #184