### PR TITLE
Adjust `intellijVersion` to v2020.2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
         // see https://www.jetbrains.com/intellij-repository/releases/
         // and https://www.jetbrains.com/intellij-repository/snapshots/
-        intellijVersion = '202.6397.59-EAP-SNAPSHOT'
+        intellijVersion = '2020.2.3'
 
         // see https://plugins.jetbrains.com/plugin/6884-handlebars-mustache/versions
         handlebarsPluginVersion = '202.6397.21'


### PR DESCRIPTION
`202.6397.59-EAP-SNAPSHOT` is no longer available on the repository, so this should hopefully fix our CI builds