### PR TITLE
many features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
         // see https://www.jetbrains.com/intellij-repository/releases/
         // and https://www.jetbrains.com/intellij-repository/snapshots/
-        intellijVersion = '202.6397.59-EAP-SNAPSHOT'
+        intellijVersion = '202.7660.26'
 
         // see https://plugins.jetbrains.com/plugin/6884-handlebars-mustache/versions
         handlebarsPluginVersion = '202.6397.21'
@@ -60,7 +60,11 @@ intellij {
     publishPlugin {
         token = System.getenv("ORG_GRADLE_PROJECT_intellijPublishToken")
     }
+    compileKotlin {
+        kotlinOptions.jvmTarget = "1.8"
+    }
 }
+
 
 test {
     testLogging {
@@ -72,3 +76,4 @@ wrapper {
     gradleVersion = '5.5.1'
     distributionType = Wrapper.DistributionType.ALL
 }
+

--- a/src/main/kotlin/com/emberjs/AttrPsiReference.kt
+++ b/src/main/kotlin/com/emberjs/AttrPsiReference.kt
@@ -1,0 +1,40 @@
+package com.emberjs
+
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
+
+class AttrPsiReference(private val element: PsiElement) : PsiReference {
+    override fun getElement(): PsiElement {
+        return element
+    }
+
+    override fun getRangeInElement(): TextRange {
+        TODO("Not yet implemented")
+    }
+
+    override fun resolve(): PsiElement? {
+        return element
+    }
+
+    override fun getCanonicalText(): String {
+        TODO("Not yet implemented")
+    }
+
+    override fun handleElementRename(newElementName: String): PsiElement {
+        TODO("Not yet implemented")
+    }
+
+    override fun bindToElement(element: PsiElement): PsiElement {
+        TODO("Not yet implemented")
+    }
+
+    override fun isReferenceTo(element: PsiElement): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun isSoft(): Boolean {
+        return true
+    }
+
+}

--- a/src/main/kotlin/com/emberjs/EmberAttrDec.kt
+++ b/src/main/kotlin/com/emberjs/EmberAttrDec.kt
@@ -1,0 +1,229 @@
+package com.emberjs
+
+import com.intellij.lang.ASTNode
+import com.intellij.lang.Language
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.*
+import com.intellij.psi.scope.PsiScopeProcessor
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.ProjectScope
+import com.intellij.psi.search.SearchScope
+import javax.swing.Icon
+
+class EmberAttrDec(private val description: String, private val reference: PsiReference) : PsiElement {
+    private val userDataMap = HashMap<Any, Any>()
+    override fun <T> getUserData(key: Key<T>): T? {
+        return this.userDataMap[key] as T?
+    }
+
+    override fun <T> putUserData(key: Key<T>, value: T?) {
+        this.userDataMap[key] = value as Any
+    }
+
+    override fun getIcon(flags: Int): Icon {
+        return this.reference.element.getIcon(flags)
+    }
+
+    override fun getProject(): Project {
+        return this.reference.element.project
+    }
+
+    override fun getLanguage(): Language {
+        return this.reference.element.language
+    }
+
+    override fun getManager(): PsiManager {
+        return this.reference.element.manager
+    }
+
+    override fun getChildren(): Array<PsiElement> {
+        return emptyArray<PsiElement>()
+    }
+
+    override fun getParent(): PsiElement? {
+        return this.reference.element.parent
+    }
+
+    override fun getFirstChild(): PsiElement? {
+        return null
+    }
+
+    override fun getLastChild(): PsiElement? {
+        return null
+    }
+
+    override fun getNextSibling(): PsiElement? {
+        return null
+    }
+
+    override fun getPrevSibling(): PsiElement? {
+        return null
+    }
+
+    override fun getContainingFile(): PsiFile? {
+        return this.reference.element.containingFile;
+    }
+
+    override fun getTextRange(): TextRange? {
+        return null
+    }
+
+    override fun getStartOffsetInParent(): Int {
+        return -1
+    }
+
+    override fun getTextLength(): Int {
+        return 0
+    }
+
+    override fun findElementAt(offset: Int): PsiElement? {
+        return null
+    }
+
+    override fun findReferenceAt(offset: Int): PsiReference? {
+        return null
+    }
+
+    override fun getTextOffset(): Int {
+        return -1
+    }
+
+    override fun getText(): String {
+        return this.description
+    }
+
+    override fun textToCharArray(): CharArray {
+        return this.description.toCharArray()
+    }
+
+    override fun getNavigationElement(): PsiElement? {
+        return this.reference.element
+    }
+
+    override fun getOriginalElement(): PsiElement? {
+        return null
+    }
+
+    override fun textMatches(text: CharSequence): Boolean {
+        return false
+    }
+
+    override fun textMatches(element: PsiElement): Boolean {
+        return false
+    }
+
+    override fun textContains(c: Char): Boolean {
+        return false
+    }
+
+    override fun accept(visitor: PsiElementVisitor) {
+        return
+    }
+
+    override fun acceptChildren(visitor: PsiElementVisitor) {
+        TODO("Not yet implemented")
+    }
+
+    override fun copy(): PsiElement {
+        TODO("Not yet implemented")
+    }
+
+    override fun add(element: PsiElement): PsiElement {
+        TODO("Not yet implemented")
+    }
+
+    override fun addBefore(element: PsiElement, anchor: PsiElement?): PsiElement {
+        TODO("Not yet implemented")
+    }
+
+    override fun addAfter(element: PsiElement, anchor: PsiElement?): PsiElement {
+        TODO("Not yet implemented")
+    }
+
+    override fun checkAdd(element: PsiElement) {
+        TODO("Not yet implemented")
+    }
+
+    override fun addRange(first: PsiElement?, last: PsiElement?): PsiElement {
+        TODO("Not yet implemented")
+    }
+
+    override fun addRangeBefore(first: PsiElement, last: PsiElement, anchor: PsiElement?): PsiElement {
+        TODO("Not yet implemented")
+    }
+
+    override fun addRangeAfter(first: PsiElement?, last: PsiElement?, anchor: PsiElement?): PsiElement {
+        TODO("Not yet implemented")
+    }
+
+    override fun delete() {
+        TODO("Not yet implemented")
+    }
+
+    override fun checkDelete() {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteChildRange(first: PsiElement?, last: PsiElement?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun replace(newElement: PsiElement): PsiElement {
+        TODO("Not yet implemented")
+    }
+
+    override fun isValid(): Boolean {
+        return true;
+    }
+
+    override fun isWritable(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getReference(): PsiReference? {
+        return this.reference
+    }
+
+    override fun getReferences(): Array<PsiReference> {
+        return arrayOf(this.reference)
+    }
+
+    override fun <T : Any?> getCopyableUserData(key: Key<T>?): T? {
+        TODO("Not yet implemented")
+    }
+
+    override fun <T : Any?> putCopyableUserData(key: Key<T>?, value: T?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun processDeclarations(processor: PsiScopeProcessor, state: ResolveState, lastParent: PsiElement?, place: PsiElement): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getContext(): PsiElement? {
+        return this.reference.element.context
+    }
+
+    override fun isPhysical(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getResolveScope(): GlobalSearchScope {
+        TODO("Not yet implemented")
+    }
+
+    override fun getUseScope(): SearchScope {
+        return ProjectScope.getProjectScope(this.project)
+    }
+
+    override fun getNode(): ASTNode? {
+        return null
+    }
+
+    override fun isEquivalentTo(another: PsiElement?): Boolean {
+        return false
+    }
+
+}

--- a/src/main/kotlin/com/emberjs/EmberAttrDec.kt
+++ b/src/main/kotlin/com/emberjs/EmberAttrDec.kt
@@ -12,10 +12,15 @@ import com.intellij.psi.search.ProjectScope
 import com.intellij.psi.search.SearchScope
 import javax.swing.Icon
 
-class EmberAttrDec(private val description: String, private val reference: PsiReference) : PsiElement {
+class EmberAttrDec(private val description: String, private val ref: PsiReference?, private val references: Array<PsiReference>?) : PsiElement {
     private val userDataMap = HashMap<Any, Any>()
+    private val reference: PsiReference
     override fun <T> getUserData(key: Key<T>): T? {
         return this.userDataMap[key] as T?
+    }
+
+    init {
+        this.reference = ref ?: references!!.first()!!
     }
 
     override fun <T> putUserData(key: Key<T>, value: T?) {
@@ -182,12 +187,12 @@ class EmberAttrDec(private val description: String, private val reference: PsiRe
         TODO("Not yet implemented")
     }
 
-    override fun getReference(): PsiReference? {
+    override fun getReference(): PsiReference {
         return this.reference
     }
 
     override fun getReferences(): Array<PsiReference> {
-        return arrayOf(this.reference)
+        return this.references ?: emptyArray()
     }
 
     override fun <T : Any?> getCopyableUserData(key: Key<T>?): T? {

--- a/src/main/kotlin/com/emberjs/EmberAttrDec.kt
+++ b/src/main/kotlin/com/emberjs/EmberAttrDec.kt
@@ -12,7 +12,7 @@ import com.intellij.psi.search.ProjectScope
 import com.intellij.psi.search.SearchScope
 import javax.swing.Icon
 
-class EmberAttrDec(private val description: String, private val ref: PsiReference?, private val references: Array<PsiReference>?) : PsiElement {
+class EmberAttrDec(private val name: String, private val description: String, ref: PsiReference?, private val references: Array<PsiReference>?) : PsiElement {
     private val userDataMap = HashMap<Any, Any>()
     private val reference: PsiReference
     override fun <T> getUserData(key: Key<T>): T? {
@@ -76,11 +76,11 @@ class EmberAttrDec(private val description: String, private val ref: PsiReferenc
     }
 
     override fun getStartOffsetInParent(): Int {
-        return -1
+        return 0
     }
 
     override fun getTextLength(): Int {
-        return 0
+        return name.length
     }
 
     override fun findElementAt(offset: Int): PsiElement? {
@@ -92,7 +92,7 @@ class EmberAttrDec(private val description: String, private val ref: PsiReferenc
     }
 
     override fun getTextOffset(): Int {
-        return -1
+        return 0
     }
 
     override fun getText(): String {
@@ -212,7 +212,7 @@ class EmberAttrDec(private val description: String, private val ref: PsiReferenc
     }
 
     override fun isPhysical(): Boolean {
-        TODO("Not yet implemented")
+        return true
     }
 
     override fun getResolveScope(): GlobalSearchScope {

--- a/src/main/kotlin/com/emberjs/EmberAttributeDescriptor.kt
+++ b/src/main/kotlin/com/emberjs/EmberAttributeDescriptor.kt
@@ -35,7 +35,8 @@ class EmberAttributeDescriptor(private val data: HashMap<String, Any?>) : XmlAtt
             val type = PsiTreeUtil.collectElementsOfType(ref.element, TypeScriptPropertySignatureImpl::class.java).firstOrNull()
             val types = type?.children?.find { it is TypeScriptUnionOrIntersectionType }?.children
             val typesStr = types?.map { it.text } ?: arrayListOf<String>()
-            this.isRequired = typesStr.isEmpty() || !(typesStr.contains("undefined") || typesStr.contains("null") || typesStr.contains("*"))
+            val isOptional = (type?.isOptional ?: true) || typesStr.isEmpty() || (typesStr.contains("undefined") || typesStr.contains("null") || typesStr.contains("*"))
+            this.isRequired = !isOptional
             if (types != null && types.all { it is TypeScriptStringLiteralTypeImpl }) {
                 this.values = typesStr
             } else {

--- a/src/main/kotlin/com/emberjs/EmberAttributeDescriptor.kt
+++ b/src/main/kotlin/com/emberjs/EmberAttributeDescriptor.kt
@@ -15,13 +15,20 @@ class EmberAttributeDescriptor(private val data: HashMap<String, Any?>) : XmlAtt
     private val declaration: PsiElement?
     private val isRequired: Boolean
     private val values: List<String>
+    val isParam: Boolean
     init {
-        this.attrName = "@" + (this.data["value"] as String?)!!
+        this.isParam = this.data.getOrDefault("isParam", false) as Boolean
+        if (!this.isParam) {
+            this.attrName = "@" + (this.data["value"] as String)
+        } else {
+            this.attrName = this.data["value"] as String
+        }
         this.description = this.data.getOrDefault("description", "") as String
         val reference = this.data.getOrDefault("reference", null) as PsiReference?
-        val references = (this.data.getOrDefault("references", null) as ArrayList<PsiReference>?)?.toTypedArray()
-        if (reference != null || references != null || references!!.isNotEmpty()) {
+        val references: Array<PsiReference>? = (this.data.getOrDefault("references", null) as ArrayList<PsiReference>?)?.toTypedArray()
+        if (reference != null || (references != null && references.isNotEmpty())) {
             this.declaration = EmberAttrDec(
+                    this.attrName,
                     this.description,
                     reference,
                     references
@@ -98,5 +105,4 @@ class EmberAttributeDescriptor(private val data: HashMap<String, Any?>) : XmlAtt
         }
         return null
     }
-
 }

--- a/src/main/kotlin/com/emberjs/EmberAttributeDescriptor.kt
+++ b/src/main/kotlin/com/emberjs/EmberAttributeDescriptor.kt
@@ -1,0 +1,90 @@
+package com.emberjs
+
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptUnionOrIntersectionType
+import com.intellij.lang.javascript.psi.ecma6.impl.TypeScriptPropertySignatureImpl
+import com.intellij.lang.javascript.psi.ecma6.impl.TypeScriptStringLiteralTypeImpl
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReference
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.xml.XmlElement
+import com.intellij.xml.XmlAttributeDescriptor
+
+class EmberAttributeDescriptor(private val data: HashMap<String, Any>) : XmlAttributeDescriptor {
+    private val attrName: String
+    private val description: String
+    private val declaration: PsiElement
+    private val isRequired: Boolean
+    private val values: List<String>
+    init {
+        this.attrName = "@" + (this.data["value"] as String?)!!
+        this.description = this.data.getOrDefault("description", "") as String
+        this.declaration = EmberAttrDec(this.description, this.data["reference"] as PsiReference)
+        val ref = this.data["reference"] as PsiReference?
+        if (ref != null) {
+            val type = PsiTreeUtil.collectElementsOfType(ref.element, TypeScriptPropertySignatureImpl::class.java).firstOrNull()
+            val types = type?.children?.find { it is TypeScriptUnionOrIntersectionType }?.children
+            val typesStr = types?.map { it.text } ?: arrayListOf<String>()
+            this.isRequired = !(typesStr.contains("undefined") || typesStr.contains("null"))
+            if (types != null && types.all { it is TypeScriptStringLiteralTypeImpl }) {
+                this.values = typesStr
+            } else {
+                this.values = arrayListOf<String>()
+            }
+        } else {
+            this.isRequired = false
+            this.values = arrayListOf<String>()
+        }
+    }
+
+    override fun getDeclaration(): PsiElement? {
+        return declaration
+    }
+
+    override fun getName(context: PsiElement?): String {
+        return this.attrName
+    }
+
+    override fun getName(): String {
+        return this.attrName
+    }
+
+    override fun init(element: PsiElement?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun isRequired(): Boolean {
+        return this.isRequired
+    }
+
+    override fun isFixed(): Boolean {
+        return false;
+    }
+
+    override fun hasIdType(): Boolean {
+        return false
+    }
+
+    override fun hasIdRefType(): Boolean {
+        return false
+    }
+
+    override fun getDefaultValue(): String? {
+        return null
+    }
+
+    override fun isEnumerated(): Boolean {
+        return this.values.isNotEmpty()
+    }
+
+    override fun getEnumeratedValues(): Array<String> {
+        return this.values.toTypedArray()
+    }
+
+    override fun validateValue(context: XmlElement?, value: String?): String? {
+        if (this.values.isNotEmpty() && this.values.contains(value)) {
+            return value
+        }
+        return null
+    }
+
+}

--- a/src/main/kotlin/com/emberjs/EmberAttributeDescriptor.kt
+++ b/src/main/kotlin/com/emberjs/EmberAttributeDescriptor.kt
@@ -35,7 +35,7 @@ class EmberAttributeDescriptor(private val data: HashMap<String, Any?>) : XmlAtt
             val type = PsiTreeUtil.collectElementsOfType(ref.element, TypeScriptPropertySignatureImpl::class.java).firstOrNull()
             val types = type?.children?.find { it is TypeScriptUnionOrIntersectionType }?.children
             val typesStr = types?.map { it.text } ?: arrayListOf<String>()
-            this.isRequired = !(typesStr.contains("undefined") || typesStr.contains("null"))
+            this.isRequired = typesStr.isEmpty() || !(typesStr.contains("undefined") || typesStr.contains("null") || typesStr.contains("*"))
             if (types != null && types.all { it is TypeScriptStringLiteralTypeImpl }) {
                 this.values = typesStr
             } else {

--- a/src/main/kotlin/com/emberjs/EmberAttributeDescriptor.kt
+++ b/src/main/kotlin/com/emberjs/EmberAttributeDescriptor.kt
@@ -9,17 +9,28 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.xml.XmlElement
 import com.intellij.xml.XmlAttributeDescriptor
 
-class EmberAttributeDescriptor(private val data: HashMap<String, Any>) : XmlAttributeDescriptor {
+class EmberAttributeDescriptor(private val data: HashMap<String, Any?>) : XmlAttributeDescriptor {
     private val attrName: String
     private val description: String
-    private val declaration: PsiElement
+    private val declaration: PsiElement?
     private val isRequired: Boolean
     private val values: List<String>
     init {
         this.attrName = "@" + (this.data["value"] as String?)!!
         this.description = this.data.getOrDefault("description", "") as String
-        this.declaration = EmberAttrDec(this.description, this.data["reference"] as PsiReference)
-        val ref = this.data["reference"] as PsiReference?
+        val reference = this.data.getOrDefault("reference", null) as PsiReference?
+        val references = (this.data.getOrDefault("references", null) as ArrayList<PsiReference>?)?.toTypedArray()
+        if (reference != null || references != null || references!!.isNotEmpty()) {
+            this.declaration = EmberAttrDec(
+                    this.description,
+                    reference,
+                    references
+            )
+        } else {
+            this.declaration = null
+        }
+
+        val ref = this.data.getOrDefault("reference", null) as PsiReference?
         if (ref != null) {
             val type = PsiTreeUtil.collectElementsOfType(ref.element, TypeScriptPropertySignatureImpl::class.java).firstOrNull()
             val types = type?.children?.find { it is TypeScriptUnionOrIntersectionType }?.children

--- a/src/main/kotlin/com/emberjs/EmberFileType.kt
+++ b/src/main/kotlin/com/emberjs/EmberFileType.kt
@@ -5,6 +5,7 @@ enum class EmberFileType(val fileExtension: String = "js") {
     COMPONENT(),
     CONTROLLER(),
     HELPER(),
+    MODIFIER(),
     INITIALIZER(),
     MIXIN(),
     MODEL(),

--- a/src/main/kotlin/com/emberjs/EmberHbsDocumentationProvider.kt
+++ b/src/main/kotlin/com/emberjs/EmberHbsDocumentationProvider.kt
@@ -24,8 +24,8 @@ class EmberHbsDocumentationProvider : DocumentationProvider, ExternalDocumentati
     override fun getUrlFor(element: PsiElement?, originalElement: PsiElement?): MutableList<String>? {
         val ref = element?.references?.firstOrNull()
         // if reference does not resolve then its an internal component/helper
-        if (ref != null && ref.resolve() == null && ref is HbsModuleReference) {
-            val name = ref.value
+        if (element != null && ref == null) {
+            val name = element.text
             return arrayOf("https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/$name?anchor=$name").toMutableList()
         }
         return null
@@ -42,11 +42,14 @@ class EmberHbsDocumentationProvider : DocumentationProvider, ExternalDocumentati
     }
 
     override fun fetchExternalDocumentation(project: Project?, element: PsiElement?, docUrls: MutableList<String>?, onHover: Boolean): String? {
-        if (docUrls == null || docUrls.size == 0) {
+        if (docUrls == null || docUrls.size == 0 || element == null) {
             return null
         }
-        val ref = element?.references?.firstOrNull()
-        val name = (ref as HbsModuleReference).value
+        val ref = element.references.firstOrNull()
+        if (ref != null) {
+            return null
+        }
+        val name = element.text
         val htmlString = this.download(docUrls.first())
         return Jsoup.parse(htmlString).select("[data-anchor='$name']")?.parents()?.first()?.toString()
     }

--- a/src/main/kotlin/com/emberjs/EmberHbsDocumentationProvider.kt
+++ b/src/main/kotlin/com/emberjs/EmberHbsDocumentationProvider.kt
@@ -1,0 +1,71 @@
+package com.emberjs
+
+import com.emberjs.hbs.HbsModuleReference
+import com.intellij.lang.documentation.DocumentationProvider
+import com.intellij.lang.documentation.ExternalDocumentationProvider
+import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.project.Project
+import com.intellij.platform.templates.github.DownloadUtil
+import com.intellij.psi.PsiElement
+import org.apache.xerces.dom.AttrImpl
+import org.apache.xerces.dom.DeferredElementNSImpl
+import org.apache.xerces.parsers.DOMParser
+import org.cyberneko.html.HTMLConfiguration
+import org.jsoup.Jsoup
+import org.w3c.dom.Node
+import org.xml.sax.InputSource
+import java.io.File
+import java.io.StringReader
+
+
+class EmberHbsDocumentationProvider : DocumentationProvider, ExternalDocumentationProvider {
+
+    override fun getUrlFor(element: PsiElement?, originalElement: PsiElement?): MutableList<String>? {
+        val ref = element?.references?.firstOrNull()
+        // if reference does not resolve then its an internal component/helper
+        if (ref != null && ref.resolve() == null && ref is HbsModuleReference) {
+            val name = ref.value
+            return arrayOf("https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/$name?anchor=$name").toMutableList()
+        }
+        return null
+    }
+
+    fun download(url: String): String {
+        val targetDir = PathManager.getTempPath()
+        val name = "ember-template-helpers-doc.html"
+        val f = File(targetDir, name)
+        if (!f.exists()) {
+            DownloadUtil.downloadAtomically(ProgressManager.getInstance().progressIndicator, url, f)
+        }
+        return f.readText()
+    }
+
+    override fun fetchExternalDocumentation(project: Project?, element: PsiElement?, docUrls: MutableList<String>?, onHover: Boolean): String? {
+        if (docUrls == null || docUrls.size == 0) {
+            return null
+        }
+        val ref = element?.references?.firstOrNull()
+        val name = (ref as HbsModuleReference).value
+        val htmlString = this.download(docUrls.first())
+        return Jsoup.parse(htmlString).select("[data-anchor='$name']")?.parents()?.first()?.toString()
+    }
+
+    override fun hasDocumentationFor(element: PsiElement?, originalElement: PsiElement?): Boolean {
+        val ref = element?.references?.firstOrNull()
+        // if reference does not resolve then its an internal component/helper
+        if (ref?.resolve() == null) {
+            return true
+        }
+        return false
+    }
+
+    override fun canPromptToConfigureDocumentation(element: PsiElement?): Boolean {
+        return false
+    }
+
+    override fun promptToConfigureDocumentation(element: PsiElement?) {
+        return
+    }
+
+}

--- a/src/main/kotlin/com/emberjs/EmberTagNameProvider.kt
+++ b/src/main/kotlin/com/emberjs/EmberTagNameProvider.kt
@@ -3,15 +3,20 @@ package com.emberjs
 import com.emberjs.icons.EmberIconProvider
 import com.emberjs.index.EmberNameIndex
 import com.emberjs.resolver.EmberName
+import com.intellij.codeInsight.completion.InsertHandler
+import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.completion.PrioritizedLookupElement
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.openapi.util.Key
 import com.intellij.psi.impl.source.html.HtmlFileImpl
 import com.intellij.psi.search.ProjectScope
 import com.intellij.psi.xml.XmlTag
+import com.intellij.util.containers.toArray
 import com.intellij.xml.XmlTagNameProvider
 
 class EmberTagNameProvider : XmlTagNameProvider {
+
     override fun addTagNameVariants(elements: MutableList<LookupElement>?, tag: XmlTag, prefix: String?) {
         if (elements == null) return
         if (prefix != null && !prefix.isEmpty()) return
@@ -32,7 +37,7 @@ class EmberTagNameProvider : XmlTagNameProvider {
             .filter { EmberNameIndex.hasContainingFiles(it, scope) }
 
             // Convert search results for LookupElements
-            .map { Pair(it.angleBracketsName, toLookupElement(it)) }
+            .map { Pair(it.path, toLookupElement(it)) }
             .toMap(componentMap)
 
         // Collect all component templates from the index
@@ -42,10 +47,10 @@ class EmberTagNameProvider : XmlTagNameProvider {
             .filter { EmberNameIndex.hasContainingFiles(it, scope) }
 
             // Filter out components that are already in the map
-            .filter { !componentMap.containsKey(it.angleBracketsName) }
+            .filter { !componentMap.containsKey(it.path) }
 
             // Convert search results for LookupElements
-            .map { Pair(it.angleBracketsName, toLookupElement(it)) }
+            .map { Pair(it.path, toLookupElement(it)) }
             .toMap(componentMap)
 
 
@@ -53,12 +58,54 @@ class EmberTagNameProvider : XmlTagNameProvider {
     }
 }
 
+class PathKeyClass : Key<String>("PATH")
+val PathKey = PathKeyClass()
+
+private class HbsInsertHandler : InsertHandler<LookupElement> {
+
+    override fun handleInsert(context: InsertionContext, item: LookupElement) {
+        // todo parse imports and merge
+        val path = item.getUserData(PathKey)
+        val fullName = item.lookupString.replace("::", "/")
+        val name = fullName.split("/").last()
+        val pattern = "\\{\\{\\s*import\\s+([\\w*\"']+[-,\\w*\\n'\" ]+)\\s+from\\s+['\"]([^'\"]+)['\"]\\s*\\}\\}"
+        val matches = Regex(pattern).findAll(context.document.text)
+        val importsSq = matches.map {
+            it.groups.filterNotNull().map { it.value }.toMutableList().takeLast(2).toMutableList()
+        }
+        val imports = importsSq.asIterable().toMutableList()
+        val m = imports.indexOfFirst { it.last() == path }
+
+        if (m != -1) {
+            val groups = imports.elementAt(m)
+            if (groups.first().contains(name)) return
+            val g = groups.elementAt(0).replace("'", "").replace("\"", "")
+            groups.removeAt(0)
+            groups[0] = "'$g,$name'"
+        } else {
+            val l = arrayOf(name, path!!)
+            imports.add(l.toMutableList())
+        }
+        var text = context.document.text
+        text = text.replace(Regex("$pattern.*\n"), "")
+        for (imp in imports.reversed()) {
+            val l = arrayOf("{{import", imp.elementAt(0), "from '${imp.elementAt(1)}'}}")
+            text = l.joinToString(" ") + "\n" + text
+        }
+        context.document.setText(text)
+        context.commitDocument()
+    }
+
+}
+
 fun toLookupElement(name: EmberName, priority: Double = 90.0): LookupElement {
     val lookupElement = LookupElementBuilder
-            .create(name.angleBracketsName)
+            .create(name.tagName)
+            .withTailText(" from ${name.path}")
             .withTypeText("component")
             .withIcon(EmberIconProvider.getIcon("component"))
             .withCaseSensitivity(true)
-
+            .withInsertHandler(HbsInsertHandler())
+    lookupElement.putUserData(PathKey, name.path)
     return PrioritizedLookupElement.withPriority(lookupElement, priority)
 }

--- a/src/main/kotlin/com/emberjs/EmberTagNameProvider.kt
+++ b/src/main/kotlin/com/emberjs/EmberTagNameProvider.kt
@@ -150,6 +150,5 @@ fun toLookupElement(name: EmberName, priority: Double = 90.0): LookupElement {
             .withTypeText("component")
             .withIcon(EmberIconProvider.getIcon("component"))
             .withCaseSensitivity(true)
-    lookupElement.putUserData(PathKey, name.path)
     return PrioritizedLookupElement.withPriority(lookupElement, priority)
 }

--- a/src/main/kotlin/com/emberjs/EmberTagNameProvider.kt
+++ b/src/main/kotlin/com/emberjs/EmberTagNameProvider.kt
@@ -1,25 +1,109 @@
 package com.emberjs
 
+import com.dmarcotte.handlebars.parsing.HbTokenTypes
+import com.dmarcotte.handlebars.psi.HbParam
+import com.dmarcotte.handlebars.psi.impl.HbOpenBlockMustacheImpl
+import com.emberjs.hbs.HbsLocalReference
 import com.emberjs.icons.EmberIconProvider
 import com.emberjs.index.EmberNameIndex
 import com.emberjs.resolver.EmberName
+import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.completion.InsertHandler
 import com.intellij.codeInsight.completion.InsertionContext
 import com.intellij.codeInsight.completion.PrioritizedLookupElement
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.lang.Language
 import com.intellij.openapi.util.Key
+import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.html.HtmlFileImpl
+import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.search.ProjectScope
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parentsWithSelf
 import com.intellij.psi.xml.XmlTag
 import com.intellij.util.containers.toArray
 import com.intellij.xml.XmlTagNameProvider
 
 class EmberTagNameProvider : XmlTagNameProvider {
 
+
+    private fun resolve(anything: PsiElement?, path: MutableList<String>, elements: MutableList<LookupElement>) {
+        var refElement: Any? = anything
+        if (anything == null) {
+            return
+        }
+
+        if (anything.references.firstOrNull() != null) {
+            resolve(anything.references.first().resolve(), path, elements)
+            return
+        }
+
+        if (anything.reference != null) {
+            resolve(anything.reference?.resolve(), path, elements)
+            return
+        }
+
+        if (refElement is HbParam) {
+            if (refElement.children.find { it is HbParam }?.text == "hash") {
+                val names = refElement.children.filter { it.elementType == HbTokenTypes.HASH }.map { it.children[0].text }
+                elements.addAll(names.map {
+                    val p = path.toMutableList()
+                    p.add(it)
+                    LookupElementBuilder.create(p.joinToString("."))
+                })
+                return
+            }
+            val ids = PsiTreeUtil.collectElements(refElement, {it.elementType == HbTokenTypes.ID && it !is LeafPsiElement } )
+            if (ids.size == 1) {
+                resolve(ids.first(), path, elements)
+                return
+            }
+        }
+        LookupElementBuilder.create(path.joinToString("."))
+    }
+
+    private fun fromLocalParams(tag: XmlTag, elements: MutableList<LookupElement>) {
+        val angleBracketBlock: XmlTag? = tag.parentsWithSelf
+                .find {
+                    it is XmlTag && it.attributes.find { it.text.startsWith("|") } != null
+                } as XmlTag?
+
+        if (angleBracketBlock != null) {
+            return angleBracketBlock.attributes.filter { it.text.startsWith("|") }.forEach {
+                val names = it.text.replace("|", "").split(" ")
+                val references = it.references.toList()
+                names.forEachIndexed { i, item ->
+                    resolve(references[i].resolve(), mutableListOf(item), elements)
+                }
+            }
+        }
+
+        // find mustache block |params|
+        val hbsView = tag.containingFile.viewProvider.getPsi(Language.findLanguageByID("Handlebars")!!)
+        val hbBlockRef = PsiTreeUtil.collectElements(hbsView, { it is HbOpenBlockMustacheImpl })
+                .filter { it.children[0].text.contains(Regex("\\|.*\\|")) }
+                .filter { block ->
+                    val htmlContent = PsiTreeUtil.collectElements(block) { it.elementType == HbTokenTypes.CONTENT && it.text.contains(tag.name) }
+                    val htmlParts = htmlContent.map { hbsView.findElementAt(it.textOffset) }
+                    htmlParts.find { part -> PsiTreeUtil.collectElements(part) { it == tag }.isNotEmpty() } != null
+                }
+        hbBlockRef.forEach {
+            val group = Regex("\\|(.*)\\|").find(it.text)
+            val names = group?.groups?.toList()?.getOrNull(0)?.value?.split(" ") ?: emptyList()
+            val refs = names.map { n -> it.children.find { it.elementType == HbTokenTypes.ID && it.text == n } }
+                    .map { it?.references?.firstOrNull() }
+            names.forEachIndexed { i, item ->
+                resolve(refs[i]?.resolve(), mutableListOf(item), elements)
+            }
+        }
+    }
+
     override fun addTagNameVariants(elements: MutableList<LookupElement>?, tag: XmlTag, prefix: String?) {
         if (elements == null) return
         if (prefix != null && !prefix.isEmpty()) return
+        fromLocalParams(tag, elements)
 
         val containingFile = tag.containingFile as? HtmlFileImpl ?: return
         val language = containingFile.contentElementType?.language ?: return
@@ -64,8 +148,7 @@ val PathKey = PathKeyClass()
 private class HbsInsertHandler : InsertHandler<LookupElement> {
 
     override fun handleInsert(context: InsertionContext, item: LookupElement) {
-        // todo parse imports and merge
-        val path = item.getUserData(PathKey)
+        val path = item.getUserData(PathKey) ?: return
         val fullName = item.lookupString.replace("::", "/")
         val name = fullName.split("/").last()
         val pattern = "\\{\\{\\s*import\\s+([\\w*\"']+[-,\\w*\\n'\" ]+)\\s+from\\s+['\"]([^'\"]+)['\"]\\s*\\}\\}"

--- a/src/main/kotlin/com/emberjs/EmberTagNameProvider.kt
+++ b/src/main/kotlin/com/emberjs/EmberTagNameProvider.kt
@@ -145,7 +145,7 @@ class EmberTagNameProvider : XmlTagNameProvider {
 
 fun toLookupElement(name: EmberName, priority: Double = 90.0): LookupElement {
     val lookupElement = LookupElementBuilder
-            .create(name.tagName)
+            .create(name.angleBracketsName)
             .withTailText(" from ${name.path}")
             .withTypeText("component")
             .withIcon(EmberIconProvider.getIcon("component"))

--- a/src/main/kotlin/com/emberjs/EmberTagNameProvider.kt
+++ b/src/main/kotlin/com/emberjs/EmberTagNameProvider.kt
@@ -142,44 +142,6 @@ class EmberTagNameProvider : XmlTagNameProvider {
     }
 }
 
-class PathKeyClass : Key<String>("PATH")
-val PathKey = PathKeyClass()
-
-private class HbsInsertHandler : InsertHandler<LookupElement> {
-
-    override fun handleInsert(context: InsertionContext, item: LookupElement) {
-        val path = item.getUserData(PathKey) ?: return
-        val fullName = item.lookupString.replace("::", "/")
-        val name = fullName.split("/").last()
-        val pattern = "\\{\\{\\s*import\\s+([\\w*\"']+[-,\\w*\\n'\" ]+)\\s+from\\s+['\"]([^'\"]+)['\"]\\s*\\}\\}"
-        val matches = Regex(pattern).findAll(context.document.text)
-        val importsSq = matches.map {
-            it.groups.filterNotNull().map { it.value }.toMutableList().takeLast(2).toMutableList()
-        }
-        val imports = importsSq.asIterable().toMutableList()
-        val m = imports.indexOfFirst { it.last() == path }
-
-        if (m != -1) {
-            val groups = imports.elementAt(m)
-            if (groups.first().contains(name)) return
-            val g = groups.elementAt(0).replace("'", "").replace("\"", "")
-            groups.removeAt(0)
-            groups[0] = "'$g,$name'"
-        } else {
-            val l = arrayOf(name, path!!)
-            imports.add(l.toMutableList())
-        }
-        var text = context.document.text
-        text = text.replace(Regex("$pattern.*\n"), "")
-        for (imp in imports.reversed()) {
-            val l = arrayOf("{{import", imp.elementAt(0), "from '${imp.elementAt(1)}'}}")
-            text = l.joinToString(" ") + "\n" + text
-        }
-        context.document.setText(text)
-        context.commitDocument()
-    }
-
-}
 
 fun toLookupElement(name: EmberName, priority: Double = 90.0): LookupElement {
     val lookupElement = LookupElementBuilder
@@ -188,7 +150,6 @@ fun toLookupElement(name: EmberName, priority: Double = 90.0): LookupElement {
             .withTypeText("component")
             .withIcon(EmberIconProvider.getIcon("component"))
             .withCaseSensitivity(true)
-            .withInsertHandler(HbsInsertHandler())
     lookupElement.putUserData(PathKey, name.path)
     return PrioritizedLookupElement.withPriority(lookupElement, priority)
 }

--- a/src/main/kotlin/com/emberjs/EmberXmlElementDescriptor.kt
+++ b/src/main/kotlin/com/emberjs/EmberXmlElementDescriptor.kt
@@ -1,21 +1,30 @@
 package com.emberjs
 
+import com.dmarcotte.handlebars.parsing.HbTokenTypes
 import com.dmarcotte.handlebars.psi.impl.HbDataImpl
+import com.dmarcotte.handlebars.psi.impl.HbOpenBlockMustacheImpl
 import com.dmarcotte.handlebars.psi.impl.HbPathImpl
 import com.emberjs.index.EmberNameIndex
 import com.emberjs.resolver.ClassOrFileReference
+import com.emberjs.utils.*
 import com.intellij.codeInsight.documentation.DocumentationManager.ORIGINAL_ELEMENT_KEY
+import com.intellij.lang.Language
+import com.intellij.lang.ecmascript6.resolve.ES6PsiUtil
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptClass
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptInterface
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptSingleType
 import com.intellij.lang.javascript.psi.ecma6.impl.TypeScriptPropertySignatureImpl
 import com.intellij.lang.javascript.psi.ecma6.impl.TypeScriptTypeAliasImpl
 import com.intellij.lang.javascript.psi.jsdoc.JSDocComment
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiManager
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.*
 import com.intellij.psi.impl.file.PsiDirectoryImpl
 import com.intellij.psi.impl.source.html.dtd.HtmlNSDescriptorImpl
 import com.intellij.psi.impl.source.xml.XmlDescriptorUtil
 import com.intellij.psi.search.ProjectScope
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parentsWithSelf
 import com.intellij.psi.xml.XmlAttribute
 import com.intellij.psi.xml.XmlTag
 import com.intellij.xml.XmlAttributeDescriptor
@@ -29,8 +38,41 @@ class EmberXmlElementDescriptor(private val tag: XmlTag, private val declaration
     val project = tag.project
 
     companion object {
+
+        fun fromLocalBlock(tag: XmlTag): PsiElement? {
+            val name = tag.name.split(".").first()
+            // find blocks with attribute |name|
+            val angleBracketBlock: XmlTag? = tag.parentsWithSelf
+                    .find {
+                        it is XmlTag && it.attributes.find {
+                            it.text.startsWith("|") && it.text.replace("|", "").split(" ").contains(name)
+                        } != null
+                    } as XmlTag?
+            if (angleBracketBlock != null) {
+                return angleBracketBlock.attributes.find {
+                    it.text.startsWith("|") && it.text.replace("|", "").split(" ").contains(name)
+                }
+            }
+
+            // find mustache block |params|
+            val hbsView = tag.containingFile.viewProvider.getPsi(Language.findLanguageByID("Handlebars")!!)
+            val hbBlockRef = PsiTreeUtil.collectElements(hbsView, { it is HbOpenBlockMustacheImpl })
+                    .filter { it.children[0].text.contains(Regex("\\|.*$name.*\\|")) }
+                    .find { block ->
+                        val htmlContent = PsiTreeUtil.collectElements(block, { it.elementType == HbTokenTypes.CONTENT && it.text.contains(name) })
+                        val htmlParts = htmlContent.map { hbsView.findElementAt(it.textOffset) }
+                        htmlParts.find { part -> PsiTreeUtil.collectElements(part) { it == tag }.isNotEmpty() } != null
+                    }
+
+            return hbBlockRef?.parent?.children?.find { it.elementType == HbTokenTypes.ID && it.text == name}
+        }
+
         fun forTag(tag: XmlTag?): EmberXmlElementDescriptor? {
             if (tag == null) return null
+            val local = fromLocalBlock(tag)
+            if (local != null) {
+                return EmberXmlElementDescriptor(tag, local)
+            }
 
             val project = tag.project
             val scope = ProjectScope.getAllScope(project)
@@ -76,46 +118,88 @@ class EmberXmlElementDescriptor(private val tag: XmlTag, private val declaration
 
     class YieldReference(element: PsiElement): PsiReferenceBase1<PsiElement>(element) {
         override fun resolve(): PsiElement? {
-            return element
+            return PsiTreeUtil.collectElements(element.parent.parent) { it.elementType == HbTokenTypes.PARAM }.first()
         }
-
     }
 
-    override fun getAttributesDescriptors(context: XmlTag?): Array<out XmlAttributeDescriptor> {
-        val result = mutableListOf<XmlAttributeDescriptor>()
-        val commonHtmlAttributes = HtmlNSDescriptorImpl.getCommonAttributeDescriptors(context)
-        val name = this.declaration.containingFile.name.split(".").first()
-        val dir = this.declaration.containingFile.parent as PsiDirectoryImpl
-        // co-located
-        var template: PsiFile? = null
-        if (name == "component") {
-            template = dir.findFile("template.hbs")
-        } else {
-            template = dir.findFile("$name.hbs")
+    fun getFileByPath(directory: PsiDirectory, path: String): PsiFile? {
+        var dir = directory
+        val parts = path.split("/").toMutableList()
+        while (parts.isNotEmpty()) {
+            val p = parts.removeAt(0)
+            val d: Any? = dir.findSubdirectory(p) ?: dir.findFile(p)
+            if (d is PsiFile) {
+                return d
+            }
+            if (d is PsiDirectory) {
+                dir = d
+                continue
+            }
+            return null
         }
+        return null
+    }
+
+    private fun resolve(element: PsiElement?): PsiElement? {
+        if (element?.reference != null) {
+            return resolve(element?.reference?.resolve())
+        }
+        if (element?.references != null && element.references.isNotEmpty()) {
+            return resolve(element.references.first().resolve())
+        }
+        return element
+    }
+
+
+    fun getReferenceData(): HashMap<String, Any> {
+        var f: PsiFile? = null
+        // if it references a block param
+        if (this.declaration.containingFile == this.tag.containingFile) {
+            f = resolve(this.declaration)?.containingFile
+        }
+        val file = f ?: this.declaration.containingFile
+        var name = file.name.split(".").first()
+        val dir = file.parent as PsiDirectoryImpl
+        // co-located
+        var template: PsiFile?
+        if (name == "component") {
+            name = "template"
+        }
+        template = dir.findFile("$name.hbs")
+        val parentModule = file.parents.find { it is PsiDirectory && it.virtualFile == file.originalVirtualFile?.parentEmberModule} as PsiDirectory
+        val path = file.parents
+                .takeWhile { it != parentModule }
+                .reversed()
+                .map { (it as PsiFileSystemItem).name }
+                .joinToString("/")
+
+        val fullPathToHbs = path.replace("app/", "addon/") + "/$name.hbs"
+        template = template ?: getFileByPath(parentModule, fullPathToHbs)
+
         val tplArgs = emptyArray<HashMap<String, Any>>().toMutableList()
-        val tplYields = emptyArray<HashMap<String, Any>>().toMutableList()
+        val tplYields = emptyArray<YieldReference>().toMutableList()
         if (template?.node?.psi != null) {
             val args = PsiTreeUtil.collectElementsOfType(template.node.psi, HbDataImpl::class.java)
             for (arg in args) {
                 val argName = arg.text.split(".").first()
                 if (tplArgs.find { it["value"] == argName } == null) {
-                    tplArgs.add(hashMapOf( "value" to argName as Any, "reference" to AttrPsiReference(arg)))
+                    tplArgs.add(hashMapOf("value" to argName as Any, "reference" to AttrPsiReference(arg)))
                 }
             }
 
-            val yields = PsiTreeUtil.collectElements(template.node.psi, { it is HbPathImpl && it.text == "yield"})
+            val yields = PsiTreeUtil.collectElements(template.node.psi, { it is HbPathImpl && it.text == "yield" })
             for (y in yields) {
-                val argName = y.text
-                tplYields.add(hashMapOf( "value" to argName as Any, "reference" to YieldReference(y)))
+                tplYields.add(YieldReference(y))
             }
         }
 
         val hasSplattributes = template?.text?.contains("...attributes") ?: false
-        val tsFile =  dir.findFile("$name.ts") ?: dir.findFile("$name.d.ts")
+        val fullPathToTs = path.replace("app/", "addon/") + "/$name.ts"
+        val fullPathToDts = path.replace("app/", "addon/") + "/$name.d.ts"
+        val tsFile = getFileByPath(parentModule, fullPathToTs) ?: getFileByPath(parentModule, fullPathToDts)
         if (tsFile != null) {
-            val argsElem = PsiTreeUtil.collectElements(tsFile.node.psi) { it is TypeScriptTypeAliasImpl && it.toString().endsWith(":Args") }
-            val signatures = PsiTreeUtil.collectElements(argsElem[0]) { it is TypeScriptPropertySignatureImpl }
+            val argsElem = findComponentArgsType(tsFile)
+            val signatures = PsiTreeUtil.collectElements(argsElem) { it is TypeScriptPropertySignatureImpl }
             for (sign in signatures) {
                 val comment = sign.children.find { it is JSDocComment }
 //                val s: TypeScriptSingleTypeImpl? = sign.children.find { it is TypeScriptSingleTypeImpl } as TypeScriptSingleTypeImpl?
@@ -129,10 +213,16 @@ class EmberXmlElementDescriptor(private val tag: XmlTag, private val declaration
                 }
             }
         }
+        return hashMapOf("hasSplattributes" to hasSplattributes, "tplArgs" to tplArgs, "tplYields" to tplYields)
+    }
 
-        val attributes = tplArgs.map { EmberAttributeDescriptor(it)  }
+    override fun getAttributesDescriptors(context: XmlTag?): Array<out XmlAttributeDescriptor> {
+        val result = mutableListOf<XmlAttributeDescriptor>()
+        val commonHtmlAttributes = HtmlNSDescriptorImpl.getCommonAttributeDescriptors(context)
+        val data = getReferenceData()
+        val attributes = (data["tplArgs"] as MutableList<HashMap<String, Any?>>).map { EmberAttributeDescriptor(it)  }
         result.addAll(attributes)
-        if (hasSplattributes) {
+        if (data["hasSplattributes"]!! as Boolean) {
             result.addAll(commonHtmlAttributes)
         }
         return result.toTypedArray()
@@ -142,8 +232,19 @@ class EmberXmlElementDescriptor(private val tag: XmlTag, private val declaration
         if (attributeName == null) {
             return null
         }
-        if (attributeName == "as" || attributeName.matches(Regex("^\\|.*\\|$"))) {
+        if (attributeName == "as") {
             return AnyXmlAttributeDescriptor(attributeName)
+        }
+        if (attributeName.matches(Regex("^\\|.*\\|$"))) {
+            val data = getReferenceData()
+            val hash = hashMapOf(
+                    "value" to attributeName,
+                    "description" to (data["tplYields"] as MutableList<YieldReference>).map {
+                        it.resolve()?.children?.filter { it.elementType == HbTokenTypes.PARAM }?.map { "yield" } ?: ""
+                    }.joinToString(" or "),
+                    "references" to data["tplYields"]
+            )
+            return EmberAttributeDescriptor(hash)
         }
         return this.getAttributesDescriptors(context).find { it.name == attributeName }
     }

--- a/src/main/kotlin/com/emberjs/EmberXmlElementDescriptor.kt
+++ b/src/main/kotlin/com/emberjs/EmberXmlElementDescriptor.kt
@@ -20,6 +20,7 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.*
 import com.intellij.psi.impl.file.PsiDirectoryImpl
 import com.intellij.psi.impl.source.html.dtd.HtmlNSDescriptorImpl
+import com.intellij.psi.impl.source.xml.XmlAttributeImpl
 import com.intellij.psi.impl.source.xml.XmlDescriptorUtil
 import com.intellij.psi.search.ProjectScope
 import com.intellij.psi.util.PsiTreeUtil
@@ -155,7 +156,7 @@ class EmberXmlElementDescriptor(private val tag: XmlTag, private val declaration
         var f: PsiFile? = null
         // if it references a block param
         if (this.declaration.containingFile == this.tag.containingFile) {
-            f = resolve(this.declaration)?.containingFile
+            f = resolve((this.declaration as XmlAttributeImpl).descriptor?.declaration?.reference?.resolve())?.containingFile
         }
         val file = f ?: this.declaration.containingFile
         var name = file.name.split(".").first()
@@ -193,6 +194,9 @@ class EmberXmlElementDescriptor(private val tag: XmlTag, private val declaration
             }
         }
 
+        if (name == "template") {
+            name = "component"
+        }
         val hasSplattributes = template?.text?.contains("...attributes") ?: false
         val fullPathToTs = path.replace("app/", "addon/") + "/$name.ts"
         val fullPathToDts = path.replace("app/", "addon/") + "/$name.d.ts"

--- a/src/main/kotlin/com/emberjs/EmberXmlElementDescriptor.kt
+++ b/src/main/kotlin/com/emberjs/EmberXmlElementDescriptor.kt
@@ -1,11 +1,21 @@
 package com.emberjs
 
+import com.dmarcotte.handlebars.psi.impl.HbDataImpl
+import com.dmarcotte.handlebars.psi.impl.HbPathImpl
 import com.emberjs.index.EmberNameIndex
+import com.emberjs.resolver.ClassOrFileReference
+import com.intellij.codeInsight.documentation.DocumentationManager.ORIGINAL_ELEMENT_KEY
+import com.intellij.lang.javascript.psi.ecma6.impl.TypeScriptPropertySignatureImpl
+import com.intellij.lang.javascript.psi.ecma6.impl.TypeScriptTypeAliasImpl
+import com.intellij.lang.javascript.psi.jsdoc.JSDocComment
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiManager
+import com.intellij.psi.impl.file.PsiDirectoryImpl
 import com.intellij.psi.impl.source.html.dtd.HtmlNSDescriptorImpl
 import com.intellij.psi.impl.source.xml.XmlDescriptorUtil
 import com.intellij.psi.search.ProjectScope
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.xml.XmlAttribute
 import com.intellij.psi.xml.XmlTag
 import com.intellij.xml.XmlAttributeDescriptor
@@ -13,6 +23,7 @@ import com.intellij.xml.XmlElementDescriptor
 import com.intellij.xml.XmlElementsGroup
 import com.intellij.xml.XmlNSDescriptor
 import com.intellij.xml.impl.schema.AnyXmlAttributeDescriptor
+import com.intellij.psi.PsiReferenceBase as PsiReferenceBase1
 
 class EmberXmlElementDescriptor(private val tag: XmlTag, private val declaration: PsiElement) : XmlElementDescriptor {
     val project = tag.project
@@ -26,7 +37,7 @@ class EmberXmlElementDescriptor(private val tag: XmlTag, private val declaration
             val psiManager: PsiManager by lazy { PsiManager.getInstance(project) }
 
             val componentTemplate = // Filter out components that are not related to this project
-                    EmberNameIndex.getFilteredKeys(scope) { it.isComponentTemplate && it.angleBracketsName == tag.name }
+                    EmberNameIndex.getFilteredKeys(scope) { it.isComponentTemplate && it.tagName == tag.name }
                             // Filter out components that are not related to this project
                             .flatMap { EmberNameIndex.getContainingFiles(it, scope) }
                             .mapNotNull { psiManager.findFile(it) }
@@ -34,9 +45,10 @@ class EmberXmlElementDescriptor(private val tag: XmlTag, private val declaration
 
             if (componentTemplate != null) return EmberXmlElementDescriptor(tag, componentTemplate)
 
-            val component = EmberNameIndex.getFilteredKeys(scope) { it.type == "component" && it.angleBracketsName == tag.name }
+            val component = EmberNameIndex.getFilteredKeys(scope) { it.type == "component" && it.tagName == tag.name }
                     .flatMap { EmberNameIndex.getContainingFiles(it, scope) }
                     .mapNotNull { psiManager.findFile(it) }
+                    .map { ClassOrFileReference(it, null).resolve() }
                     .firstOrNull()
 
             if (component != null) return EmberXmlElementDescriptor(tag, component)
@@ -48,7 +60,9 @@ class EmberXmlElementDescriptor(private val tag: XmlTag, private val declaration
     override fun getDeclaration(): PsiElement = declaration
     override fun getName(context: PsiElement?): String = (context as? XmlTag)?.name ?: name
     override fun getName(): String = tag.localName
-    override fun init(element: PsiElement?) {}
+    override fun init(element: PsiElement?) {
+        element?.putUserData(ORIGINAL_ELEMENT_KEY, null)
+    }
     override fun getQualifiedName(): String = name
     override fun getDefaultName(): String = name
 
@@ -60,15 +74,78 @@ class EmberXmlElementDescriptor(private val tag: XmlTag, private val declaration
         return XmlDescriptorUtil.getElementDescriptor(childTag, contextTag)
     }
 
+    class YieldReference(element: PsiElement): PsiReferenceBase1<PsiElement>(element) {
+        override fun resolve(): PsiElement? {
+            return element
+        }
+
+    }
+
     override fun getAttributesDescriptors(context: XmlTag?): Array<out XmlAttributeDescriptor> {
         val result = mutableListOf<XmlAttributeDescriptor>()
         val commonHtmlAttributes = HtmlNSDescriptorImpl.getCommonAttributeDescriptors(context)
-        result.addAll(commonHtmlAttributes)
+        val name = this.declaration.containingFile.name.split(".").first()
+        val dir = this.declaration.containingFile.parent as PsiDirectoryImpl
+        // co-located
+        var template: PsiFile? = null
+        if (name == "component") {
+            template = dir.findFile("template.hbs")
+        } else {
+            template = dir.findFile("$name.hbs")
+        }
+        val tplArgs = emptyArray<HashMap<String, Any>>().toMutableList()
+        val tplYields = emptyArray<HashMap<String, Any>>().toMutableList()
+        if (template?.node?.psi != null) {
+            val args = PsiTreeUtil.collectElementsOfType(template.node.psi, HbDataImpl::class.java)
+            for (arg in args) {
+                val argName = arg.text.split(".").first()
+                if (tplArgs.find { it["value"] == argName } == null) {
+                    tplArgs.add(hashMapOf( "value" to argName as Any, "reference" to AttrPsiReference(arg)))
+                }
+            }
+
+            val yields = PsiTreeUtil.collectElements(template.node.psi, { it is HbPathImpl && it.text == "yield"})
+            for (y in yields) {
+                val argName = y.text
+                tplYields.add(hashMapOf( "value" to argName as Any, "reference" to YieldReference(y)))
+            }
+        }
+
+        val hasSplattributes = template?.text?.contains("...attributes") ?: false
+        val tsFile =  dir.findFile("$name.ts") ?: dir.findFile("$name.d.ts")
+        if (tsFile != null) {
+            val argsElem = PsiTreeUtil.collectElements(tsFile.node.psi) { it is TypeScriptTypeAliasImpl && it.toString().endsWith(":Args") }
+            val signatures = PsiTreeUtil.collectElements(argsElem[0]) { it is TypeScriptPropertySignatureImpl }
+            for (sign in signatures) {
+                val comment = sign.children.find { it is JSDocComment }
+//                val s: TypeScriptSingleTypeImpl? = sign.children.find { it is TypeScriptSingleTypeImpl } as TypeScriptSingleTypeImpl?
+                val attr = sign.toString().split(":").last()
+                val data = tplArgs.find { it["value"] as String == attr } ?: HashMap()
+                data["value"] = attr
+                data["reference"] = AttrPsiReference(sign)
+                data["description"] = comment?.text ?: ""
+                if (tplArgs.find { it["value"] as String == attr } == null) {
+                    tplArgs.add(data)
+                }
+            }
+        }
+
+        val attributes = tplArgs.map { EmberAttributeDescriptor(it)  }
+        result.addAll(attributes)
+        if (hasSplattributes) {
+            result.addAll(commonHtmlAttributes)
+        }
         return result.toTypedArray()
     }
 
     override fun getAttributeDescriptor(attributeName: String?, context: XmlTag?): XmlAttributeDescriptor? {
-        return AnyXmlAttributeDescriptor(attributeName)
+        if (attributeName == null) {
+            return null
+        }
+        if (attributeName == "as" || attributeName.matches(Regex("^\\|.*\\|$"))) {
+            return AnyXmlAttributeDescriptor(attributeName)
+        }
+        return this.getAttributesDescriptors(context).find { it.name == attributeName }
     }
     override fun getAttributeDescriptor(attribute: XmlAttribute?): XmlAttributeDescriptor?
             = getAttributeDescriptor(attribute?.name, attribute?.parent)

--- a/src/main/kotlin/com/emberjs/EmberXmlElementDescriptor.kt
+++ b/src/main/kotlin/com/emberjs/EmberXmlElementDescriptor.kt
@@ -91,7 +91,7 @@ class EmberXmlElementDescriptor(private val tag: XmlTag, private val declaration
             val component = EmberNameIndex.getFilteredKeys(scope) { it.type == "component" && it.tagName == tag.name }
                     .flatMap { EmberNameIndex.getContainingFiles(it, scope) }
                     .mapNotNull { psiManager.findFile(it) }
-                    .map { ClassOrFileReference(it, null).resolve() }
+                    .map { ClassOrFileReference(it).resolve() }
                     .firstOrNull()
 
             if (component != null) return EmberXmlElementDescriptor(tag, component)

--- a/src/main/kotlin/com/emberjs/cli/EmberCliProjectConfigurator.kt
+++ b/src/main/kotlin/com/emberjs/cli/EmberCliProjectConfigurator.kt
@@ -30,6 +30,7 @@ import org.jetbrains.jps.model.module.JpsModuleSourceRootType
 class EmberCliProjectConfigurator : DirectoryProjectConfigurator {
     override fun configureProject(project: Project, baseDir: VirtualFile, moduleRef: Ref<Module>) {
         val module = ModuleManager.getInstance(project).modules.singleOrNull()
+        System.out.println("configureProject: $module ${baseDir.isEmberFolder}")
         if (module != null && baseDir.isEmberFolder) {
             setupEmber(project, module, baseDir)
         }
@@ -39,6 +40,7 @@ class EmberCliProjectConfigurator : DirectoryProjectConfigurator {
         fun setupEmber(project: Project, module: Module, baseDir: VirtualFile) {
             val model = ModuleRootManager.getInstance(module).modifiableModel
             val entry = MarkRootActionBase.findContentEntry(model, baseDir)
+            System.out.println("setupEmber $entry $baseDir $model")
             if (entry != null) {
                 ApplicationManager.getApplication().runWriteAction {
                     setupEmber(project, entry, baseDir)
@@ -73,10 +75,12 @@ class EmberCliProjectConfigurator : DirectoryProjectConfigurator {
         }
 
         private fun setupLibrary(name: String, project: Project, root: VirtualFile, create: Boolean) {
+            System.out.println("setupLibrary: $name $create ${root.findChild(name)}")
             val folder = root.findChild(name) ?: return
 
             JSLibraryManager.getInstance(project).apply {
                 val libName = "$name ${root.name}"
+                System.out.println("checking: $libName $create")
 
                 val library = getLibraryByName(libName)
                 if (create && library == null) {
@@ -90,8 +94,10 @@ class EmberCliProjectConfigurator : DirectoryProjectConfigurator {
                     removeLibrary(library)
                 }
 
-                if (create)
+                if (create) {
+                    System.out.println("lib associateWithProject: " + libName)
                     libraryMappings.associateWithProject(libName)
+                }
                 else
                     libraryMappings.disassociateWithProject(libName)
 

--- a/src/main/kotlin/com/emberjs/external/ember-helpers.ts
+++ b/src/main/kotlin/com/emberjs/external/ember-helpers.ts
@@ -1,0 +1,39 @@
+class Component {}
+
+function each([items]: [any[]]) {}
+
+function _let([value]: [any]) {}
+
+function fn([action, params]: [Function, any[]|undefined]) {}
+
+function array(params: any[]): any[] {
+  return []
+}
+function component([compnent, ...params]: [string|Component, any[]], hash: {[x: string]: any}): Component|undefined {
+  return
+}
+function concat(params: string[]): string {
+  return ""
+}
+
+function _debugger(params: string[]) {}
+
+function eachIn([object]: [Object]) {}
+
+function get([object, path]: [Object, string]): any {}
+
+const helpers = {
+  each,
+  'let': _let,
+  fn,
+  component,
+  array,
+  concat,
+  'debugger': _debugger,
+  'each-in': eachIn,
+  get
+}
+
+export default helpers;
+
+

--- a/src/main/kotlin/com/emberjs/hbs/HbsBuiltinHelperCompletionProvider.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsBuiltinHelperCompletionProvider.kt
@@ -1,15 +1,23 @@
 package com.emberjs.hbs
 
+import com.dmarcotte.handlebars.psi.impl.HbPathImpl
+import com.emberjs.utils.parents
 import com.intellij.codeInsight.completion.CompletionParameters
 import com.intellij.codeInsight.completion.CompletionProvider
 import com.intellij.codeInsight.completion.CompletionResultSet
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.psi.util.parentsWithSelf
 import com.intellij.util.ProcessingContext
 
-class HbsBuiltinHelperCompletionProvider(vararg helpers: String) : CompletionProvider<CompletionParameters>() {
+
+
+class HbsBuiltinHelperCompletionProvider(val helpers: List<String>) : CompletionProvider<CompletionParameters>() {
     val lookupElements = helpers.map { LookupElementBuilder.create(it) }
 
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        val path = parameters.position.parentsWithSelf.toList().find { it is HbPathImpl }
+        if (path != null && path.text.contains(".")) return
+        if (parameters.position.parent.references.find { it is HbsLocalReference } != null) return
         result.addAllElements(lookupElements)
     }
 }

--- a/src/main/kotlin/com/emberjs/hbs/HbsCompletionContributor.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsCompletionContributor.kt
@@ -1,10 +1,57 @@
 package com.emberjs.hbs
 
 import com.emberjs.hbs.HbsPatterns.BLOCK_MUSTACHE_NAME_ID
+import com.emberjs.hbs.HbsPatterns.BLOCK_MUSTACHE_PARAM
+import com.emberjs.hbs.HbsPatterns.MUSTACHE_ID_MISSING
+import com.emberjs.hbs.HbsPatterns.MUSTACHE_ID
 import com.emberjs.hbs.HbsPatterns.SIMPLE_MUSTACHE_NAME_ID
 import com.emberjs.hbs.HbsPatterns.SUB_EXPR_NAME_ID
 import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionType
+
+
+val InternalsWithBlock = (
+        "component\n" +
+        "each\n" +
+        "each-in\n" +
+        "if\n" +
+        "input\n" +
+        "let\n" +
+        "link-to\n" +
+        "mount\n" +
+        "outlet\n" +
+        "query-params\n" +
+        "textarea\n" +
+        "unbound\n" +
+        "unless\n" +
+        "with\n").split("\n")
+
+val InternalsWithoutBlock = ("action\n" +
+        "array\n" +
+        "component\n" +
+        "concat\n" +
+        "debugger\n" +
+        "fn\n" +
+        "get\n" +
+        "hasBlock\n" +
+        "hasBlockParams\n" +
+        "hash\n" +
+        "if\n" +
+        "in-element\n" +
+        "input\n" +
+        "link-to\n" +
+        "loc\n" +
+        "log\n" +
+        "mount\n" +
+        "mut\n" +
+        "on\n" +
+        "outlet\n" +
+        "query-params\n" +
+        "textarea\n" +
+        "unbound\n" +
+        "unless\n" +
+        "yield").split("\n")
+
 
 /**
  * The `HbsCompletionContributor` class is responsible for registering all
@@ -13,15 +60,15 @@ import com.intellij.codeInsight.completion.CompletionType
  */
 class HbsCompletionContributor : CompletionContributor() {
     init {
-        extend(CompletionType.BASIC, SIMPLE_MUSTACHE_NAME_ID, HbsBuiltinHelperCompletionProvider(
-                "action", "component", "debugger", "get", "if", "input", "link-to", "loc", "log",
-                "outlet", "partial", "render", "textarea", "unbound"))
+        extend(CompletionType.BASIC, SIMPLE_MUSTACHE_NAME_ID, HbsBuiltinHelperCompletionProvider(InternalsWithoutBlock))
+        extend(CompletionType.BASIC, BLOCK_MUSTACHE_NAME_ID, HbsBuiltinHelperCompletionProvider(InternalsWithBlock))
+        extend(CompletionType.BASIC, SUB_EXPR_NAME_ID, HbsBuiltinHelperCompletionProvider(InternalsWithoutBlock))
 
-        extend(CompletionType.BASIC, BLOCK_MUSTACHE_NAME_ID, HbsBuiltinHelperCompletionProvider(
-                "component", "each", "each-in", "if", "link-to", "unless", "with"))
-
-        extend(CompletionType.BASIC, SUB_EXPR_NAME_ID, HbsBuiltinHelperCompletionProvider(
-                "action", "component", "concat", "get", "hash", "if", "loc", "mut", "query-params",
-                "readonly", "unbound", "unless"))
+        extend(CompletionType.BASIC, SIMPLE_MUSTACHE_NAME_ID, HbsLocalCompletion())
+        extend(CompletionType.BASIC, BLOCK_MUSTACHE_NAME_ID, HbsLocalCompletion())
+        extend(CompletionType.BASIC, SUB_EXPR_NAME_ID, HbsLocalCompletion())
+        extend(CompletionType.BASIC, MUSTACHE_ID, HbsLocalCompletion())
+        extend(CompletionType.BASIC, BLOCK_MUSTACHE_PARAM, HbsLocalCompletion())
+        extend(CompletionType.BASIC, MUSTACHE_ID_MISSING, HbsLocalCompletion())
     }
 }

--- a/src/main/kotlin/com/emberjs/hbs/HbsCompletionContributor.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsCompletionContributor.kt
@@ -3,7 +3,7 @@ package com.emberjs.hbs
 import com.emberjs.hbs.HbsPatterns.BLOCK_MUSTACHE_NAME_ID
 import com.emberjs.hbs.HbsPatterns.BLOCK_MUSTACHE_PARAM
 import com.emberjs.hbs.HbsPatterns.IMPORT_NAMES
-import com.emberjs.hbs.HbsPatterns.IMPORT_PATH
+import com.emberjs.hbs.HbsPatterns.IMPORT_PATH_AUTOCOMPLETE
 import com.emberjs.hbs.HbsPatterns.MUSTACHE_ID_MISSING
 import com.emberjs.hbs.HbsPatterns.MUSTACHE_ID
 import com.emberjs.hbs.HbsPatterns.SIMPLE_MUSTACHE_NAME_ID
@@ -12,47 +12,48 @@ import com.intellij.codeInsight.completion.CompletionContributor
 import com.intellij.codeInsight.completion.CompletionType
 
 
-val InternalsWithBlock = (
-        "component\n" +
-        "each\n" +
-        "each-in\n" +
-        "if\n" +
-        "input\n" +
-        "let\n" +
-        "link-to\n" +
-        "mount\n" +
-        "outlet\n" +
-        "query-params\n" +
-        "textarea\n" +
-        "unbound\n" +
-        "unless\n" +
-        "with\n").split("\n")
+val InternalsWithBlock = arrayListOf(
+        "component",
+        "each",
+        "each-in",
+        "if",
+        "input",
+        "let",
+        "link-to",
+        "mount",
+        "outlet",
+        "query-params",
+        "textarea",
+        "unbound",
+        "unless",
+        "with")
 
-val InternalsWithoutBlock = ("action\n" +
-        "array\n" +
-        "component\n" +
-        "concat\n" +
-        "debugger\n" +
-        "fn\n" +
-        "get\n" +
-        "hasBlock\n" +
-        "hasBlockParams\n" +
-        "hash\n" +
-        "if\n" +
-        "in-element\n" +
-        "input\n" +
-        "link-to\n" +
-        "loc\n" +
-        "log\n" +
-        "mount\n" +
-        "mut\n" +
-        "on\n" +
-        "outlet\n" +
-        "query-params\n" +
-        "textarea\n" +
-        "unbound\n" +
-        "unless\n" +
-        "yield").split("\n")
+val InternalsWithoutBlock = arrayListOf(
+        "action",
+        "array",
+        "component",
+        "concat",
+        "debugger",
+        "fn",
+        "get",
+        "hasBlock",
+        "hasBlockParams",
+        "hash",
+        "if",
+        "in-element",
+        "input",
+        "link-to",
+        "loc",
+        "log",
+        "mount",
+        "mut",
+        "on",
+        "outlet",
+        "query-params",
+        "textarea",
+        "unbound",
+        "unless",
+        "yield")
 
 
 /**
@@ -71,7 +72,7 @@ class HbsCompletionContributor : CompletionContributor() {
         extend(CompletionType.BASIC, SUB_EXPR_NAME_ID, HbsLocalCompletion())
         extend(CompletionType.BASIC, MUSTACHE_ID, HbsLocalCompletion())
         extend(CompletionType.BASIC, IMPORT_NAMES, HbsLocalCompletion())
-        extend(CompletionType.BASIC, IMPORT_PATH, HbsLocalCompletion())
+        extend(CompletionType.BASIC, IMPORT_PATH_AUTOCOMPLETE, HbsLocalCompletion())
         extend(CompletionType.BASIC, BLOCK_MUSTACHE_PARAM, HbsLocalCompletion())
         extend(CompletionType.BASIC, MUSTACHE_ID_MISSING, HbsLocalCompletion())
     }

--- a/src/main/kotlin/com/emberjs/hbs/HbsCompletionContributor.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsCompletionContributor.kt
@@ -2,6 +2,8 @@ package com.emberjs.hbs
 
 import com.emberjs.hbs.HbsPatterns.BLOCK_MUSTACHE_NAME_ID
 import com.emberjs.hbs.HbsPatterns.BLOCK_MUSTACHE_PARAM
+import com.emberjs.hbs.HbsPatterns.IMPORT_NAMES
+import com.emberjs.hbs.HbsPatterns.IMPORT_PATH
 import com.emberjs.hbs.HbsPatterns.MUSTACHE_ID_MISSING
 import com.emberjs.hbs.HbsPatterns.MUSTACHE_ID
 import com.emberjs.hbs.HbsPatterns.SIMPLE_MUSTACHE_NAME_ID
@@ -68,6 +70,8 @@ class HbsCompletionContributor : CompletionContributor() {
         extend(CompletionType.BASIC, BLOCK_MUSTACHE_NAME_ID, HbsLocalCompletion())
         extend(CompletionType.BASIC, SUB_EXPR_NAME_ID, HbsLocalCompletion())
         extend(CompletionType.BASIC, MUSTACHE_ID, HbsLocalCompletion())
+        extend(CompletionType.BASIC, IMPORT_NAMES, HbsLocalCompletion())
+        extend(CompletionType.BASIC, IMPORT_PATH, HbsLocalCompletion())
         extend(CompletionType.BASIC, BLOCK_MUSTACHE_PARAM, HbsLocalCompletion())
         extend(CompletionType.BASIC, MUSTACHE_ID_MISSING, HbsLocalCompletion())
     }

--- a/src/main/kotlin/com/emberjs/hbs/HbsComponentReference.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsComponentReference.kt
@@ -7,4 +7,8 @@ class HbsComponentReference(element: PsiElement) : HbsModuleReference(element, "
     override fun matches(module: EmberName): Boolean {
         return super.matches(module) || (module.type == "template" && module.name == "components/$value")
     }
+
+    override fun resolve(): PsiElement? {
+        return multiResolve(false).firstOrNull()?.element
+    }
 }

--- a/src/main/kotlin/com/emberjs/hbs/HbsLocalCompletion.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsLocalCompletion.kt
@@ -4,6 +4,7 @@ import com.dmarcotte.handlebars.parsing.HbTokenTypes
 import com.dmarcotte.handlebars.psi.HbParam
 import com.dmarcotte.handlebars.psi.impl.HbBlockWrapperImpl
 import com.dmarcotte.handlebars.psi.impl.HbPathImpl
+import com.emberjs.utils.followReferences
 import com.emberjs.utils.parents
 import com.emberjs.utils.resolveHelper
 import com.intellij.codeInsight.completion.*
@@ -81,8 +82,15 @@ class HbsLocalCompletion : CompletionProvider<CompletionParameters>() {
     }
 
     fun addHelperCompletions(element: PsiElement, result: CompletionResultSet) {
-        val file = element.children[0].references[0].resolve()?.containingFile ?: return
-        val func = resolveHelper(file)
+        val file = followReferences(element.children[0])
+        var func: JSFunction? = null
+        if (file is JSFunction) {
+            func = file
+        }
+        if (file is PsiFile) {
+            func = resolveHelper(file)
+        }
+
         if (func != null) {
             val hash = func.parameterList?.parameters?.last()
             resolveJsType(hash?.jsType ?: hash?.inferredType, result, "=")

--- a/src/main/kotlin/com/emberjs/hbs/HbsLocalCompletion.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsLocalCompletion.kt
@@ -4,6 +4,7 @@ import com.dmarcotte.handlebars.parsing.HbTokenTypes
 import com.dmarcotte.handlebars.psi.HbParam
 import com.dmarcotte.handlebars.psi.impl.HbBlockWrapperImpl
 import com.dmarcotte.handlebars.psi.impl.HbPathImpl
+import com.emberjs.utils.findFirstHbsParamFromParam
 import com.emberjs.utils.followReferences
 import com.emberjs.utils.parents
 import com.emberjs.utils.resolveHelper
@@ -102,9 +103,7 @@ class HbsLocalCompletion : CompletionProvider<CompletionParameters>() {
         val element = parameters.position
         val txt = element.parents.find { it is HbPathImpl }?.text!!.replace("IntellijIdeaRulezzz", "")
 
-        val helperElement = element.parentsWithSelf
-                .find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN_SEXPR }
-                ?.children?.getOrNull(1)
+        val helperElement = findFirstHbsParamFromParam(element)
         if (helperElement != null) {
             addHelperCompletions(helperElement, result)
         }

--- a/src/main/kotlin/com/emberjs/hbs/HbsLocalCompletion.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsLocalCompletion.kt
@@ -1,50 +1,45 @@
 package com.emberjs.hbs
 
 import com.dmarcotte.handlebars.parsing.HbTokenTypes
+import com.dmarcotte.handlebars.psi.HbParam
 import com.dmarcotte.handlebars.psi.impl.HbBlockWrapperImpl
-import com.dmarcotte.handlebars.psi.impl.HbMustacheNameImpl
 import com.dmarcotte.handlebars.psi.impl.HbPathImpl
 import com.emberjs.utils.parents
+import com.emberjs.utils.resolveHelper
 import com.intellij.codeInsight.completion.*
-import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.codeInsight.lookup.LookupElementBuilder
-import com.intellij.lang.ASTNode
 import com.intellij.lang.Language
 import com.intellij.lang.ecmascript6.psi.JSClassExpression
-import com.intellij.lang.ecmascript6.psi.impl.ES6ClassExpressionImpl
-import com.intellij.lang.ecmascript6.resolve.ES6PsiUtil
-import com.intellij.lang.javascript.JSDocCompositeElementType
-import com.intellij.lang.javascript.JSElementTypes
-import com.intellij.lang.javascript.completion.JSCompletionContributor
-import com.intellij.lang.javascript.psi.JSExpression
-import com.intellij.lang.javascript.psi.JSField
-import com.intellij.lang.javascript.psi.JSReferenceExpression
-import com.intellij.lang.javascript.psi.ecma6.impl.TypeScriptVariableImpl
-import com.intellij.lang.javascript.psi.impl.JSReferenceExpressionImpl
-import com.intellij.lang.javascript.psi.impl.JSThisExpressionImpl
+import com.intellij.lang.javascript.psi.*
 import com.intellij.lang.javascript.psi.impl.JSVariableImpl
 import com.intellij.lang.javascript.psi.jsdoc.impl.JSDocCommentImpl
 import com.intellij.lang.javascript.psi.types.JSRecordTypeImpl
-import com.intellij.lang.javascript.psi.types.JSSimpleRecordTypeImpl
-import com.intellij.lang.javascript.psi.types.JSTypeBaseImpl
-import com.intellij.lang.javascript.types.JSDocCommentElementType
-import com.intellij.navigation.ItemPresentation
-import com.intellij.openapi.project.Project
-import com.intellij.openapi.util.Key
-import com.intellij.openapi.util.TextRange
 import com.intellij.psi.*
-import com.intellij.psi.scope.PsiScopeProcessor
-import com.intellij.psi.search.GlobalSearchScope
-import com.intellij.psi.search.SearchScope
+import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
-import com.intellij.util.Consumer
+import com.intellij.psi.util.parentsWithSelf
+import com.intellij.psi.xml.XmlAttribute
 import com.intellij.util.ProcessingContext
-import javax.swing.Icon
-import kotlin.math.max
 
 
 class HbsLocalCompletion : CompletionProvider<CompletionParameters>() {
+
+    fun resolveJsType(jsType: JSType?, result: CompletionResultSet, suffix:String="") {
+        if (jsType?.sourceElement is JSDocCommentImpl) {
+            val doc = jsType.sourceElement as JSDocCommentImpl
+            if (doc.tags[0].value?.reference?.resolve() != null) {
+                resolve(doc.tags[0].value?.reference?.resolve()!!, result)
+            }
+            return
+        }
+        if (jsType is JSRecordTypeImpl) {
+            val names = (jsType).propertyNames
+            result.addAllElements(names.map { LookupElementBuilder.create(it + suffix) })
+            return
+        }
+
+    }
 
     fun resolve(anything: PsiElement?, result: CompletionResultSet) {
         var refElement: Any? = anything
@@ -60,47 +55,73 @@ class HbsLocalCompletion : CompletionProvider<CompletionParameters>() {
             resolve(anything.reference?.resolve(), result)
         }
 
+        if (refElement is HbParam) {
+            if (refElement.children.find { it is HbParam }?.text == "hash") {
+                val names = refElement.children.filter { it.elementType == HbTokenTypes.HASH }.map { it.children[0].text }
+                result.addAllElements(names.map { LookupElementBuilder.create(it) })
+            }
+            val ids = PsiTreeUtil.collectElements(refElement, {it.elementType == HbTokenTypes.ID && it !is LeafPsiElement } )
+            if (ids.size == 1) {
+                resolve(ids.first(), result)
+            }
+        }
+
         if (refElement is JSClassExpression) {
             result.addAllElements(refElement.fields.map { LookupElementBuilder.create(it.name!!) })
             result.addAllElements(refElement.functions.map { LookupElementBuilder.create(it.name!!) })
         }
 
         if (refElement is JSField) {
-            if (refElement.jsType?.sourceElement is JSDocCommentImpl) {
-                val doc = refElement.jsType?.sourceElement as JSDocCommentImpl
-                if (doc.tags[0].value?.reference?.resolve() != null) {
-                    resolve(doc.tags[0].value?.reference?.resolve()!!, result)
-                }
-                return
-            }
-            if (refElement.jsType is JSRecordTypeImpl) {
-                val names = (refElement.jsType as JSRecordTypeImpl).propertyNames
-                result.addAllElements(names.map { LookupElementBuilder.create(it) })
-                return
-            }
+            resolveJsType(refElement.jsType, result)
             if (refElement is JSVariableImpl<*,*> && refElement.doGetExplicitlyDeclaredType() != null) {
                 val jstype = refElement.doGetExplicitlyDeclaredType()
-                if (jstype is JSRecordTypeImpl) {
-                    result.addAllElements(jstype.propertyNames.map { LookupElementBuilder.create(it) })
-                }
+                resolveJsType(jstype, result)
             }
+        }
+    }
+
+    fun addHelperCompletions(element: PsiElement, result: CompletionResultSet) {
+        val file = element.children[0].references[0].resolve()?.containingFile ?: return
+        val func = resolveHelper(file)
+        if (func != null) {
+            val hash = func.parameterList?.parameters?.last()
+            resolveJsType(hash?.jsType ?: hash?.inferredType, result, "=")
         }
     }
 
     override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
         val regex = Regex("\\|.*\\|")
-        val txt = parameters.position.parents.find { it is HbPathImpl }?.text!!.replace("IntellijIdeaRulezzz", "")
-        val blocks = PsiTreeUtil.collectElements(parameters.originalFile.node.psi) { it.text.contains(regex) }
-                .filter { it is HbBlockWrapperImpl || it.toString().endsWith("CONTENT)") }
+        val element = parameters.position
+        val txt = element.parents.find { it is HbPathImpl }?.text!!.replace("IntellijIdeaRulezzz", "")
+
+        val helperElement = element.parentsWithSelf
+                .find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN_SEXPR }
+                ?.children?.getOrNull(1)
+        if (helperElement != null) {
+            addHelperCompletions(helperElement, result)
+        }
+        // find all |blocks| from mustache
+        val blocks = PsiTreeUtil.collectElements(parameters.originalFile) { it is HbBlockWrapperImpl }
+                .filter { it.children[0].text.contains(regex) }
+                .filter { PsiTreeUtil.collectElements(it, { it == element }).isNotEmpty() }
+
+        // find all |blocks| from component tags, needs html view
+        val htmlView = parameters.originalFile.viewProvider.getPsi(Language.findLanguageByID("HTML")!!)
+        val angleBracketBlocks = PsiTreeUtil.collectElements(htmlView, { it is XmlAttribute && it.text.startsWith("|") }).map { it }
+
+        // collect blocks which have the element as a child
+        val validBlocks = angleBracketBlocks.filter { it ->
+            val hbsFragments = PsiTreeUtil.collectElements(it) { it.elementType == HbTokenTypes.OUTER_ELEMENT_TYPE }.toList()
+            val hbsParts = hbsFragments.map { element.containingFile.findElementAt(it.textOffset)!!.parent.parent }
+            hbsParts.find { PsiTreeUtil.collectElements(it) { it == element }.isNotEmpty() } != null
+        }
+        for (block in validBlocks) {
+            val names = block.text.replace("|", "").split(" ")
+            result.addAllElements(names.map { LookupElementBuilder.create(it) })
+        }
         for (block in blocks) {
-            if (block is HbBlockWrapperImpl) {
-                val refs = block.children[0].children.filter { it.elementType.toString().endsWith("ID") }
-                result.addAllElements(refs.map { LookupElementBuilder.create(it.text) })
-            } else {
-                val reg = Regex("\\|([a-z A-Z0-9]*)\\|")
-                val refs = reg.find(block.text)!!.groups[1]!!.value.split(" ")
-                result.addAllElements(refs.map { LookupElementBuilder.create(it) })
-            }
+            val refs = block.children[0].children.filter { it.elementType == HbTokenTypes.ID }
+            result.addAllElements(refs.map { LookupElementBuilder.create(it.text) })
         }
         if ("this".startsWith(txt)) {
             result.addElement(LookupElementBuilder.create("this"))

--- a/src/main/kotlin/com/emberjs/hbs/HbsLocalCompletion.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsLocalCompletion.kt
@@ -1,0 +1,120 @@
+package com.emberjs.hbs
+
+import com.dmarcotte.handlebars.parsing.HbTokenTypes
+import com.dmarcotte.handlebars.psi.impl.HbBlockWrapperImpl
+import com.dmarcotte.handlebars.psi.impl.HbMustacheNameImpl
+import com.dmarcotte.handlebars.psi.impl.HbPathImpl
+import com.emberjs.utils.parents
+import com.intellij.codeInsight.completion.*
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.lang.ASTNode
+import com.intellij.lang.Language
+import com.intellij.lang.ecmascript6.psi.JSClassExpression
+import com.intellij.lang.ecmascript6.psi.impl.ES6ClassExpressionImpl
+import com.intellij.lang.ecmascript6.resolve.ES6PsiUtil
+import com.intellij.lang.javascript.JSDocCompositeElementType
+import com.intellij.lang.javascript.JSElementTypes
+import com.intellij.lang.javascript.completion.JSCompletionContributor
+import com.intellij.lang.javascript.psi.JSExpression
+import com.intellij.lang.javascript.psi.JSField
+import com.intellij.lang.javascript.psi.JSReferenceExpression
+import com.intellij.lang.javascript.psi.ecma6.impl.TypeScriptVariableImpl
+import com.intellij.lang.javascript.psi.impl.JSReferenceExpressionImpl
+import com.intellij.lang.javascript.psi.impl.JSThisExpressionImpl
+import com.intellij.lang.javascript.psi.impl.JSVariableImpl
+import com.intellij.lang.javascript.psi.jsdoc.impl.JSDocCommentImpl
+import com.intellij.lang.javascript.psi.types.JSRecordTypeImpl
+import com.intellij.lang.javascript.psi.types.JSSimpleRecordTypeImpl
+import com.intellij.lang.javascript.psi.types.JSTypeBaseImpl
+import com.intellij.lang.javascript.types.JSDocCommentElementType
+import com.intellij.navigation.ItemPresentation
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Key
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.*
+import com.intellij.psi.scope.PsiScopeProcessor
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.search.SearchScope
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.elementType
+import com.intellij.util.Consumer
+import com.intellij.util.ProcessingContext
+import javax.swing.Icon
+import kotlin.math.max
+
+
+class HbsLocalCompletion : CompletionProvider<CompletionParameters>() {
+
+    fun resolve(anything: PsiElement?, result: CompletionResultSet) {
+        var refElement: Any? = anything
+        if (anything == null) {
+            return
+        }
+
+        if (anything.references.find { it is HbsLocalReference } != null) {
+            resolve(anything.references.find { it is HbsLocalReference }!!.resolve(), result)
+        }
+
+        if (anything.reference is HbsLocalReference) {
+            resolve(anything.reference?.resolve(), result)
+        }
+
+        if (refElement is JSClassExpression) {
+            result.addAllElements(refElement.fields.map { LookupElementBuilder.create(it.name!!) })
+            result.addAllElements(refElement.functions.map { LookupElementBuilder.create(it.name!!) })
+        }
+
+        if (refElement is JSField) {
+            if (refElement.jsType?.sourceElement is JSDocCommentImpl) {
+                val doc = refElement.jsType?.sourceElement as JSDocCommentImpl
+                if (doc.tags[0].value?.reference?.resolve() != null) {
+                    resolve(doc.tags[0].value?.reference?.resolve()!!, result)
+                }
+                return
+            }
+            if (refElement.jsType is JSRecordTypeImpl) {
+                val names = (refElement.jsType as JSRecordTypeImpl).propertyNames
+                result.addAllElements(names.map { LookupElementBuilder.create(it) })
+                return
+            }
+            if (refElement is JSVariableImpl<*,*> && refElement.doGetExplicitlyDeclaredType() != null) {
+                val jstype = refElement.doGetExplicitlyDeclaredType()
+                if (jstype is JSRecordTypeImpl) {
+                    result.addAllElements(jstype.propertyNames.map { LookupElementBuilder.create(it) })
+                }
+            }
+        }
+    }
+
+    override fun addCompletions(parameters: CompletionParameters, context: ProcessingContext, result: CompletionResultSet) {
+        val regex = Regex("\\|.*\\|")
+        val txt = parameters.position.parents.find { it is HbPathImpl }?.text!!.replace("IntellijIdeaRulezzz", "")
+        val blocks = PsiTreeUtil.collectElements(parameters.originalFile.node.psi) { it.text.contains(regex) }
+                .filter { it is HbBlockWrapperImpl || it.toString().endsWith("CONTENT)") }
+        for (block in blocks) {
+            if (block is HbBlockWrapperImpl) {
+                val refs = block.children[0].children.filter { it.elementType.toString().endsWith("ID") }
+                result.addAllElements(refs.map { LookupElementBuilder.create(it.text) })
+            } else {
+                val reg = Regex("\\|([a-z A-Z0-9]*)\\|")
+                val refs = reg.find(block.text)!!.groups[1]!!.value.split(" ")
+                result.addAllElements(refs.map { LookupElementBuilder.create(it) })
+            }
+        }
+        if ("this".startsWith(txt)) {
+            result.addElement(LookupElementBuilder.create("this"))
+        }
+        if (parameters.position.parent.prevSibling.elementType == HbTokenTypes.SEP) {
+            resolve(parameters.position.parent.prevSibling?.prevSibling, result)
+        }
+        val mustache = parameters.position.parent
+        val res = mustache?.references?.find { it.resolve() != null }
+        if (res?.resolve() != null) {
+            val psiExp = res.resolve()
+            if (psiExp != null) {
+                resolve(psiExp, result)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/emberjs/hbs/HbsLocalCompletion.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsLocalCompletion.kt
@@ -115,13 +115,13 @@ class HbsLocalCompletion : CompletionProvider<CompletionParameters>() {
 
         // find all |blocks| from component tags, needs html view
         val htmlView = parameters.originalFile.viewProvider.getPsi(Language.findLanguageByID("HTML")!!)
-        val angleBracketBlocks = PsiTreeUtil.collectElements(htmlView, { it is XmlAttribute && it.text.startsWith("|") }).map { it }
+        val angleBracketBlocks = PsiTreeUtil.collectElements(htmlView, { it is XmlAttribute && it.text.startsWith("|") }).map { it.parent }
 
         // collect blocks which have the element as a child
         val validBlocks = angleBracketBlocks.filter { it ->
             val hbsFragments = PsiTreeUtil.collectElements(it) { it.elementType == HbTokenTypes.OUTER_ELEMENT_TYPE }.toList()
             val hbsParts = hbsFragments.map { element.containingFile.findElementAt(it.textOffset)!!.parent.parent }
-            hbsParts.find { PsiTreeUtil.collectElements(it) { it == element }.isNotEmpty() } != null
+            hbsParts.find { PsiTreeUtil.collectElements(it) { it == element.parent }.isNotEmpty() } != null
         }
         for (block in validBlocks) {
             val names = block.text.replace("|", "").split(" ")

--- a/src/main/kotlin/com/emberjs/hbs/HbsLocalReference.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsLocalReference.kt
@@ -181,6 +181,7 @@ fun toLocalReference(element: PsiElement): PsiReference? {
     val angleBracketBlocks = PsiTreeUtil.collectElements(htmlView, { it is XmlAttribute && it.text.startsWith("|") })
             .filter{ it.text.replace("|", "").split(" ").contains(name) }
             .map { it.parent }
+
     val validBlock = angleBracketBlocks.filter { it ->
         val hbsFragments = PsiTreeUtil.collectElements(it) { it.elementType == HbTokenTypes.OUTER_ELEMENT_TYPE }.toList()
         val hbsParts = hbsFragments.map { element.containingFile.findElementAt(it.textOffset)!!.parent.parent }

--- a/src/main/kotlin/com/emberjs/hbs/HbsLocalReference.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsLocalReference.kt
@@ -3,18 +3,18 @@ package com.emberjs.hbs
 import com.dmarcotte.handlebars.parsing.HbTokenTypes
 import com.dmarcotte.handlebars.psi.HbMustacheName
 import com.dmarcotte.handlebars.psi.HbOpenBlockMustache
+import com.dmarcotte.handlebars.psi.HbParam
 import com.dmarcotte.handlebars.psi.HbPsiElement
 import com.dmarcotte.handlebars.psi.impl.HbOpenBlockMustacheImpl
 import com.dmarcotte.handlebars.psi.impl.HbSimpleMustacheImpl
 import com.dmarcotte.handlebars.psi.impl.HbStatementsImpl
 import com.emberjs.utils.parents
 import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.lang.Language
 import com.intellij.lang.ecmascript6.psi.JSClassExpression
 import com.intellij.lang.ecmascript6.psi.impl.ES6ClassExpressionImpl
 import com.intellij.lang.ecmascript6.resolve.ES6PsiUtil
-import com.intellij.lang.javascript.psi.JSField
-import com.intellij.lang.javascript.psi.JSType
-import com.intellij.lang.javascript.psi.JSTypeOwner
+import com.intellij.lang.javascript.psi.*
 import com.intellij.lang.javascript.psi.ecma6.JSTypedEntity
 import com.intellij.lang.javascript.psi.ecma6.impl.TypeScriptFieldImpl
 import com.intellij.lang.javascript.psi.impl.JSReferenceExpressionImpl
@@ -28,7 +28,11 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiReference
 import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.html.HtmlTag
+import com.intellij.psi.impl.source.html.HtmlTagImpl
+import com.intellij.psi.templateLanguages.OuterLanguageElement
 import com.intellij.psi.util.*
+import com.intellij.psi.xml.XmlAttribute
 import org.jetbrains.annotations.NotNull
 import kotlin.math.max
 import kotlin.math.min
@@ -40,12 +44,34 @@ fun resolveToJs(any: Any?, path: List<String>, resolveIncomplete: Boolean = fals
         return resolveToJs(ref?.resolve(), path, resolveIncomplete)
     }
 
+    if (any is HbParam) {
+        if (any.children[0].elementType == HbTokenTypes.OPEN_SEXPR) {
+            if (any.children[1].text == "hash") {
+                val name = path.first()
+                val res = any.children.find { it.elementType == HbTokenTypes.HASH && it.children[0].text == name }
+                val ref = PsiTreeUtil.collectElements(res, { it.references.find { it is HbsLocalReference } != null }).firstOrNull()
+                if (ref != null) {
+                    val hbsRef = ref.references.find { it is HbsLocalReference }!!
+                    return resolveToJs(hbsRef.resolve(), path.subList(1, max(path.lastIndex, 1)), resolveIncomplete)
+                }
+                return res
+            }
+        }
+        if (any.children[0] is HbMustacheName) {
+            val lastId = any.children[0].children[0].children.findLast { it.elementType == HbTokenTypes.ID }
+            return resolveToJs(lastId, path, resolveIncomplete)
+        }
+    }
+
     if (any is PsiFile) {
         var cls = ES6PsiUtil.findDefaultExport(any)
+        // find class (components or helpers with class)
         cls = PsiTreeUtil.findChildOfType(cls, JSClassExpression::class.java)
+        // find function (for helpers)
+        cls = cls ?: PsiTreeUtil.findChildOfType(cls, JSCallExpression::class.java)
         if (cls == null) {
             val ref = PsiTreeUtil.findChildOfType(any, JSReferenceExpressionImpl::class.java)
-            cls = ref?.resolve() as ES6ClassExpressionImpl?
+            cls = ref?.resolve() as JSElement?
         }
         return resolveToJs(cls, path, resolveIncomplete)
     }
@@ -76,11 +102,11 @@ fun resolveToJs(any: Any?, path: List<String>, resolveIncomplete: Boolean = fals
             val tag = doc.tags.find { it.text.startsWith("@type") }
             val res = tag?.value?.reference?.resolve()
             if (res != null) {
-                return resolveToJs(res, path.slice(IntRange(1, max(path.lastIndex, 1))), resolveIncomplete)
+                return resolveToJs(res, path.subList(1, max(path.lastIndex, 1)), resolveIncomplete)
             }
         }
         if (jsType is JSSimpleRecordTypeImpl) {
-            val elem = (jsType as JSSimpleRecordTypeImpl).findPropertySignature(path.first())?.memberSource?.singleElement
+            val elem = jsType.findPropertySignature(path.first())?.memberSource?.singleElement
             return resolveToJs(elem, path.subList(1, max(path.lastIndex, 1)), resolveIncomplete)
         }
         if (any is JSVariableImpl<*, *> && any.doGetExplicitlyDeclaredType() != null) {
@@ -93,8 +119,32 @@ fun resolveToJs(any: Any?, path: List<String>, resolveIncomplete: Boolean = fals
     return null
 }
 
+fun handleEmberHelpers(element: PsiElement): HbsLocalReference? {
+    if (element.parent is HbOpenBlockMustache) {
+        val mustacheName = element.parent.children.find { it is HbMustacheName }?.text
+        if (mustacheName == "let" || mustacheName == "each") {
+            val param = PsiTreeUtil.findSiblingBackward(element, HbTokenTypes.PARAM, null)
+            if (mustacheName == "let") {
+                return HbsLocalReference(element, param)
+            }
+            if (mustacheName == "each") {
+                if (param?.references?.first()?.resolve() is HbPsiElement) {
+                    return HbsLocalReference(element, param.parent)
+                } else {
+                    var jsRef = param?.references?.first()?.resolve()
+                    jsRef = resolveToJs(jsRef, emptyList(), false)
+                    if (jsRef is JSTypeOwner && jsRef.jsType is JSArrayType) {
+                        return HbsLocalReference(element, (jsRef.jsType as JSArrayType).type?.sourceElement)
+                    }
+                }
+            }
+        }
+    }
+    return null
+}
+
 fun toLocalReference(element: PsiElement): PsiReference? {
-    val name = element.text
+    val name = element.text.replace("IntellijIdeaRulezzz", "")
     var sibling = PsiTreeUtil.findSiblingBackward(element, HbTokenTypes.ID, null)
     if (name == "this" && sibling == null) {
         val fname = element.containingFile.name.split(".").first()
@@ -112,43 +162,45 @@ fun toLocalReference(element: PsiElement): PsiReference? {
         }
     }
 
-    if (element.parent is HbOpenBlockMustache) {
-        val mustacheName = element.parent.children.find { it is HbMustacheName }?.text
-        if (mustacheName == "let" || mustacheName == "each") {
-            val param = PsiTreeUtil.findSiblingBackward(element, HbTokenTypes.PARAM, null)
-            val ref = PsiTreeUtil.collectElements(param, { it.elementType == HbTokenTypes.ID }).last()
-            if (mustacheName == "let") {
-                return HbsLocalReference(element, ref.parent)
-            }
-            if (mustacheName == "each") {
-                if (ref.parent.references.first().resolve() is HbPsiElement) {
-                    return HbsLocalReference(element, ref.parent)
-                } else {
-                    var jsRef = ref.parent.references.first().resolve()
-                    jsRef = resolveToJs(jsRef, emptyList(), false)
-                    if (jsRef is JSTypeOwner && jsRef.jsType is JSArrayType) {
-                        return HbsLocalReference(element, (jsRef.jsType as JSArrayType).type?.sourceElement)
-                    }
-                }
-            }
-        }
+    val ref = handleEmberHelpers(element)
+    if (ref != null) {
+        return ref
     }
 
+    // for this.x.y
     if (sibling != null && sibling.references.find { it is HbsLocalReference } != null) {
         return HbsLocalReference(element, resolveToJs(sibling.references.find { it is HbsLocalReference }!!.resolve(), listOf(element.text)))
     }
+
+    // any |block param|
     val hbblockRefs = PsiTreeUtil.collectElements(element.containingFile, { it is HbOpenBlockMustacheImpl })
             .filter {
-                PsiTreeUtil.collectElements(PsiTreeUtil.getNextSiblingOfType(it, HbStatementsImpl::class.java), { it == element }) != null
+                PsiTreeUtil.collectElements(PsiTreeUtil.getNextSiblingOfType(it, HbStatementsImpl::class.java), { it == element }).isNotEmpty()
             }
-    val angleBracketblocks = PsiTreeUtil.collectElements(element.containingFile, { it.elementType == HbTokenTypes.CONTENT })
-            .filter { it.siblings().find { PsiTreeUtil.collectElements(it, { it == element }).isNotEmpty() } != null }
-    val angleBlockRef = angleBracketblocks.find { it.text.contains(Regex("\\|.*$name.*\\|")) }
-    val blockRef = hbblockRefs.find { it.text.contains(Regex("\\|.*$name.*\\|")) }
-    val blockVal = blockRef?.children?.filter { it.elementType.toString().endsWith("ID") }?.find { it.text == name }
+    val htmlView = element.containingFile.viewProvider.getPsi(Language.findLanguageByID("HTML")!!)
+    val angleBracketBlocks = PsiTreeUtil.collectElements(htmlView, { it is XmlAttribute && it.text.startsWith("|") })
+            .filter{ it.text.replace("|", "").split(" ").contains(name) }
+            .map { it.parent }
+    val validBlock = angleBracketBlocks.filter { it ->
+        val hbsFragments = PsiTreeUtil.collectElements(it) { it.elementType == HbTokenTypes.OUTER_ELEMENT_TYPE }.toList()
+        val hbsParts = hbsFragments.map { element.containingFile.findElementAt(it.textOffset)!!.parent.parent }
+        hbsParts.find { PsiTreeUtil.collectElements(it) { it == element }.isNotEmpty() } != null
+    }.firstOrNull()
 
-    if (blockRef != null || blockVal != null || angleBlockRef != null) {
-        return HbsLocalReference(element, blockVal ?: blockRef ?: angleBlockRef!!)
+    val blockRef = hbblockRefs.find { it.text.contains(Regex("\\|.*$name.*\\|")) }
+    val blockVal = blockRef?.children?.filter { it.elementType == HbTokenTypes.ID }?.find { it.text == name }
+
+
+    if (blockRef != null || blockVal != null || validBlock != null) {
+        if (validBlock != null) {
+
+            val tag  = validBlock as HtmlTagImpl?
+            val r = tag?.attributes?.find { it.text.startsWith("|") }!!
+            val desc = tag.descriptor?.getAttributeDescriptor(r)
+            val i = r.text.split("|")[1].split(" ").indexOf(name)
+            return HbsLocalReference(element, desc?.declaration?.references?.getOrNull(i)?.resolve())
+        }
+        return HbsLocalReference(element, blockVal ?: blockRef)
     }
     return null
 }
@@ -159,7 +211,7 @@ class HbsLocalReference(private val leaf: PsiElement, val target: PsiElement?) :
     }
 
     override fun getRangeInElement(): TextRange {
-        return leaf.textRangeInParent
+        return TextRange(0, leaf.textLength)
     }
 
     override fun calculateDefaultRangeInElement(): TextRange {

--- a/src/main/kotlin/com/emberjs/hbs/HbsLocalReference.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsLocalReference.kt
@@ -143,6 +143,11 @@ fun handleEmberHelpers(element: PsiElement): HbsLocalReference? {
     return null
 }
 
+fun referenceImports(name: String) {
+    val imports = PsiTreeUtil.collectElements(element.containingFile, { it.elementType == HbTokenTypes.OPEN && it.parent.text == "{{import"}).map { it.parent }
+    imports.find { it.children[2].text.split(",").contains(name) }
+}
+
 fun toLocalReference(element: PsiElement): PsiReference? {
     val name = element.text.replace("IntellijIdeaRulezzz", "")
     var sibling = PsiTreeUtil.findSiblingBackward(element, HbTokenTypes.ID, null)
@@ -161,6 +166,12 @@ fun toLocalReference(element: PsiElement): PsiReference? {
             return HbsLocalReference(element, resolveToJs(file, listOf()))
         }
     }
+
+    if (element.parents.find { it is HbOpenBlockMustache && it.text.startsWith("{{import")}) {
+
+    }
+
+    val importRef = referenceImports(element)
 
     val ref = handleEmberHelpers(element)
     if (ref != null) {

--- a/src/main/kotlin/com/emberjs/hbs/HbsLocalReference.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsLocalReference.kt
@@ -1,0 +1,168 @@
+package com.emberjs.hbs
+
+import com.dmarcotte.handlebars.parsing.HbTokenTypes
+import com.dmarcotte.handlebars.psi.HbMustacheName
+import com.dmarcotte.handlebars.psi.HbOpenBlockMustache
+import com.dmarcotte.handlebars.psi.HbPsiElement
+import com.dmarcotte.handlebars.psi.impl.HbOpenBlockMustacheImpl
+import com.dmarcotte.handlebars.psi.impl.HbSimpleMustacheImpl
+import com.dmarcotte.handlebars.psi.impl.HbStatementsImpl
+import com.emberjs.utils.parents
+import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.lang.ecmascript6.psi.JSClassExpression
+import com.intellij.lang.ecmascript6.psi.impl.ES6ClassExpressionImpl
+import com.intellij.lang.ecmascript6.resolve.ES6PsiUtil
+import com.intellij.lang.javascript.psi.JSField
+import com.intellij.lang.javascript.psi.JSType
+import com.intellij.lang.javascript.psi.JSTypeOwner
+import com.intellij.lang.javascript.psi.ecma6.JSTypedEntity
+import com.intellij.lang.javascript.psi.ecma6.impl.TypeScriptFieldImpl
+import com.intellij.lang.javascript.psi.impl.JSReferenceExpressionImpl
+import com.intellij.lang.javascript.psi.impl.JSVariableImpl
+import com.intellij.lang.javascript.psi.jsdoc.impl.JSDocCommentImpl
+import com.intellij.lang.javascript.psi.types.JSArrayType
+import com.intellij.lang.javascript.psi.types.JSRecordTypeImpl
+import com.intellij.lang.javascript.psi.types.JSSimpleRecordTypeImpl
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiReference
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.util.*
+import org.jetbrains.annotations.NotNull
+import kotlin.math.max
+import kotlin.math.min
+
+fun resolveToJs(any: Any?, path: List<String>, resolveIncomplete: Boolean = false): PsiElement? {
+
+    if (any is PsiElement && any.references.find { it is HbsLocalReference } != null) {
+        val ref = any.references.find { it is HbsLocalReference }
+        return resolveToJs(ref?.resolve(), path, resolveIncomplete)
+    }
+
+    if (any is PsiFile) {
+        var cls = ES6PsiUtil.findDefaultExport(any)
+        cls = PsiTreeUtil.findChildOfType(cls, JSClassExpression::class.java)
+        if (cls == null) {
+            val ref = PsiTreeUtil.findChildOfType(any, JSReferenceExpressionImpl::class.java)
+            cls = ref?.resolve() as ES6ClassExpressionImpl?
+        }
+        return resolveToJs(cls, path, resolveIncomplete)
+    }
+
+    if (path.isEmpty()) {
+        return any as PsiElement?
+    }
+
+    if (any is JSClassExpression) {
+        val n = path.first()
+        val f = any.fields.find { it.name == n } ?: any.functions.find { it.name == n }
+        if (f == null && resolveIncomplete) {
+            return any;
+        }
+        return resolveToJs(f, path.subList(1, max(path.lastIndex, 1)), resolveIncomplete)
+    }
+
+    var jsType: JSType? = null
+    if (any is JSTypedEntity) {
+        jsType = any.jsType
+    }
+    if (any is JSTypeOwner) {
+        jsType = any.jsType
+    }
+    if (jsType != null) {
+        if (jsType.sourceElement is JSDocCommentImpl) {
+            val doc = jsType.sourceElement as JSDocCommentImpl
+            val tag = doc.tags.find { it.text.startsWith("@type") }
+            val res = tag?.value?.reference?.resolve()
+            if (res != null) {
+                return resolveToJs(res, path.slice(IntRange(1, max(path.lastIndex, 1))), resolveIncomplete)
+            }
+        }
+        if (jsType is JSSimpleRecordTypeImpl) {
+            val elem = (jsType as JSSimpleRecordTypeImpl).findPropertySignature(path.first())?.memberSource?.singleElement
+            return resolveToJs(elem, path.subList(1, max(path.lastIndex, 1)), resolveIncomplete)
+        }
+        if (any is JSVariableImpl<*, *> && any.doGetExplicitlyDeclaredType() != null) {
+            val jstype = any.doGetExplicitlyDeclaredType()
+            if (jstype is JSRecordTypeImpl) {
+                return resolveToJs(jstype.sourceElement, path.subList(1, max(path.lastIndex, 1)), resolveIncomplete)
+            }
+        }
+    }
+    return null
+}
+
+fun toLocalReference(element: PsiElement): PsiReference? {
+    val name = element.text
+    var sibling = PsiTreeUtil.findSiblingBackward(element, HbTokenTypes.ID, null)
+    if (name == "this" && sibling == null) {
+        val fname = element.containingFile.name.split(".").first()
+        var fileName = fname
+        if (fileName == "template") {
+            fileName = "component"
+        }
+        val dir = element.containingFile.originalFile.containingDirectory
+        val file = dir?.findFile("$fileName.js")
+                ?: dir?.findFile("$fileName.ts")
+                ?: dir?.findFile("controller.js")
+                ?: dir?.findFile("controller.ts")
+        if (file != null) {
+            return HbsLocalReference(element, resolveToJs(file, listOf()))
+        }
+    }
+
+    if (element.parent is HbOpenBlockMustache) {
+        val mustacheName = element.parent.children.find { it is HbMustacheName }?.text
+        if (mustacheName == "let" || mustacheName == "each") {
+            val param = PsiTreeUtil.findSiblingBackward(element, HbTokenTypes.PARAM, null)
+            val ref = PsiTreeUtil.collectElements(param, { it.elementType == HbTokenTypes.ID }).last()
+            if (mustacheName == "let") {
+                return HbsLocalReference(element, ref.parent)
+            }
+            if (mustacheName == "each") {
+                if (ref.parent.references.first().resolve() is HbPsiElement) {
+                    return HbsLocalReference(element, ref.parent)
+                } else {
+                    var jsRef = ref.parent.references.first().resolve()
+                    jsRef = resolveToJs(jsRef, emptyList(), false)
+                    if (jsRef is JSTypeOwner && jsRef.jsType is JSArrayType) {
+                        return HbsLocalReference(element, (jsRef.jsType as JSArrayType).type?.sourceElement)
+                    }
+                }
+            }
+        }
+    }
+
+    if (sibling != null && sibling.references.find { it is HbsLocalReference } != null) {
+        return HbsLocalReference(element, resolveToJs(sibling.references.find { it is HbsLocalReference }!!.resolve(), listOf(element.text)))
+    }
+    val hbblockRefs = PsiTreeUtil.collectElements(element.containingFile, { it is HbOpenBlockMustacheImpl })
+            .filter {
+                PsiTreeUtil.collectElements(PsiTreeUtil.getNextSiblingOfType(it, HbStatementsImpl::class.java), { it == element }) != null
+            }
+    val angleBracketblocks = PsiTreeUtil.collectElements(element.containingFile, { it.elementType == HbTokenTypes.CONTENT })
+            .filter { it.siblings().find { PsiTreeUtil.collectElements(it, { it == element }).isNotEmpty() } != null }
+    val angleBlockRef = angleBracketblocks.find { it.text.contains(Regex("\\|.*$name.*\\|")) }
+    val blockRef = hbblockRefs.find { it.text.contains(Regex("\\|.*$name.*\\|")) }
+    val blockVal = blockRef?.children?.filter { it.elementType.toString().endsWith("ID") }?.find { it.text == name }
+
+    if (blockRef != null || blockVal != null || angleBlockRef != null) {
+        return HbsLocalReference(element, blockVal ?: blockRef ?: angleBlockRef!!)
+    }
+    return null
+}
+
+class HbsLocalReference(private val leaf: PsiElement, val target: PsiElement?) : PsiReferenceBase<PsiElement>(leaf) {
+    override fun resolve(): PsiElement? {
+        return target
+    }
+
+    override fun getRangeInElement(): TextRange {
+        return leaf.textRangeInParent
+    }
+
+    override fun calculateDefaultRangeInElement(): TextRange {
+        return leaf.textRangeInParent
+    }
+}

--- a/src/main/kotlin/com/emberjs/hbs/HbsModuleReference.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsModuleReference.kt
@@ -4,18 +4,10 @@ import com.emberjs.index.EmberNameIndex
 import com.emberjs.lookup.EmberLookupElementBuilder
 import com.emberjs.resolver.ClassOrFileReference
 import com.emberjs.resolver.EmberName
-import com.intellij.lang.Language
-import com.intellij.lang.ecmascript6.resolve.ES6PsiUtil
-import com.intellij.lang.javascript.psi.JSObjectLiteralExpression
-import com.intellij.lang.javascript.psi.JSRecordType
-import com.intellij.lang.javascript.psi.types.primitives.JSObjectType
 import com.intellij.openapi.util.TextRange
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.*
 import com.intellij.psi.PsiElementResolveResult.createResults
 import com.intellij.psi.search.ProjectScope
-import netscape.javascript.JSObject
-import java.io.File
 
 open class HbsModuleReference(element: PsiElement, val moduleType: String) :
         PsiPolyVariantReferenceBase<PsiElement>(element, TextRange(0, element.textLength), true) {
@@ -44,8 +36,6 @@ open class HbsModuleReference(element: PsiElement, val moduleType: String) :
     }
 
     override fun getVariants(): Array<out Any?> {
-
-
 
         // Collect all components from the index
         return EmberNameIndex.getFilteredKeys(scope) { it.type == moduleType }

--- a/src/main/kotlin/com/emberjs/hbs/HbsModuleReference.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsModuleReference.kt
@@ -2,6 +2,7 @@ package com.emberjs.hbs
 
 import com.emberjs.index.EmberNameIndex
 import com.emberjs.lookup.EmberLookupElementBuilder
+import com.emberjs.resolver.ClassOrFileReference
 import com.emberjs.resolver.EmberName
 import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
@@ -32,6 +33,7 @@ open class HbsModuleReference(element: PsiElement, val moduleType: String) :
                 // Convert search results for LookupElements
                 .map { psiManager.findFile(it) }
                 .filterNotNull()
+                .map { ClassOrFileReference(it, null).resolve() }
                 .let(::createResults)
     }
 

--- a/src/main/kotlin/com/emberjs/hbs/HbsModuleReference.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsModuleReference.kt
@@ -4,13 +4,18 @@ import com.emberjs.index.EmberNameIndex
 import com.emberjs.lookup.EmberLookupElementBuilder
 import com.emberjs.resolver.ClassOrFileReference
 import com.emberjs.resolver.EmberName
+import com.intellij.lang.Language
+import com.intellij.lang.ecmascript6.resolve.ES6PsiUtil
+import com.intellij.lang.javascript.psi.JSObjectLiteralExpression
+import com.intellij.lang.javascript.psi.JSRecordType
+import com.intellij.lang.javascript.psi.types.primitives.JSObjectType
 import com.intellij.openapi.util.TextRange
-import com.intellij.psi.PsiElement
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.*
 import com.intellij.psi.PsiElementResolveResult.createResults
-import com.intellij.psi.PsiManager
-import com.intellij.psi.PsiPolyVariantReferenceBase
-import com.intellij.psi.ResolveResult
 import com.intellij.psi.search.ProjectScope
+import netscape.javascript.JSObject
+import java.io.File
 
 open class HbsModuleReference(element: PsiElement, val moduleType: String) :
         PsiPolyVariantReferenceBase<PsiElement>(element, TextRange(0, element.textLength), true) {
@@ -25,6 +30,7 @@ open class HbsModuleReference(element: PsiElement, val moduleType: String) :
 
     override fun multiResolve(incompleteCode: Boolean): Array<out ResolveResult> {
         // Collect all components from the index
+
         return EmberNameIndex.getFilteredKeys(scope) { matches(it) }
 
                 // Filter out components that are not related to this project
@@ -33,11 +39,14 @@ open class HbsModuleReference(element: PsiElement, val moduleType: String) :
                 // Convert search results for LookupElements
                 .map { psiManager.findFile(it) }
                 .filterNotNull()
-                .map { ClassOrFileReference(it, null).resolve() }
+                .map { ClassOrFileReference(it).resolve() }
                 .let(::createResults)
     }
 
     override fun getVariants(): Array<out Any?> {
+
+
+
         // Collect all components from the index
         return EmberNameIndex.getFilteredKeys(scope) { it.type == moduleType }
 

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
@@ -108,7 +108,7 @@ class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, Any?> {
         if (type is JSArrayType || type is JSTupleType) {
             if (type is JSTupleType) {
                 val names = type.sourceElement?.children?.map { it.text } ?: emptyList<String>()
-                text += names.mapIndexed { index, s -> "$s:${type.getTypeByIndex(index) ?: "unknown"}" }
+                text += names.mapIndexed { index, s -> "$s:${type.getTypeByIndex(index) ?: "unknown"}" }.joinToString(",")
             } else {
                 val arrayType = type as JSArrayType
                 text += arrayName + ":" + (arrayType.type?.resolvedTypeText ?: "*")

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
@@ -4,6 +4,7 @@ import com.dmarcotte.handlebars.parsing.HbTokenTypes
 import com.dmarcotte.handlebars.psi.HbParam
 import com.emberjs.utils.followReferences
 import com.emberjs.utils.resolveHelper
+import com.emberjs.utils.resolveModifier
 import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.lang.javascript.psi.JSFunction
@@ -56,7 +57,9 @@ class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSFunction> {
 
     override fun findElementForParameterInfo(context: CreateParameterInfoContext): JSFunction? {
         val psiElement = context.file.findElementAt(context.offset)
-        return findHelperFunction(psiElement)
+        val func = findHelperFunction(psiElement)
+        context.itemsToShow = func?.parameters
+        return func
     }
 
     override fun showParameterInfo(element: PsiElement, context: CreateParameterInfoContext) {
@@ -79,8 +82,16 @@ class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSFunction> {
 
     override fun updateUI(p: JSFunction?, context: ParameterInfoUIContext) {
         var text = ""
-        val array = p?.parameters?.firstOrNull()
-        val hash = p?.parameters?.lastOrNull()
+        if (p == null) {
+            return
+        }
+        val modifier = resolveModifier(p.containingFile)
+        if (modifier != null) {
+            val param = p.parameters.lastOrNull()
+            param?.jsType
+        }
+        val array = p.parameters.firstOrNull()
+        val hash = p.parameters.lastOrNull()
         if (array != null) {
             val names = array.children.getOrNull(0)?.children?.map { it.text }
             val type = array.jsType

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
@@ -8,16 +8,21 @@ import com.emberjs.utils.resolveModifier
 import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.lang.javascript.psi.JSFunction
+import com.intellij.lang.javascript.psi.JSParameter
 import com.intellij.lang.javascript.psi.JSParameterListElement
+import com.intellij.lang.javascript.psi.JSRecordType
+import com.intellij.lang.javascript.psi.types.JSArrayType
+import com.intellij.lang.javascript.psi.types.JSSimpleRecordTypeImpl
 import com.intellij.lang.javascript.psi.types.JSTupleType
 import com.intellij.lang.parameterInfo.*
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.elementType
 import com.intellij.psi.util.parents
+import com.intellij.util.containers.toArray
 
 
-class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSFunction> {
+class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSParameter> {
     override fun couldShowInLookup(): Boolean {
         return true
     }
@@ -58,8 +63,18 @@ class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSFunction> {
     override fun findElementForParameterInfo(context: CreateParameterInfoContext): JSFunction? {
         val psiElement = context.file.findElementAt(context.offset)
         val func = findHelperFunction(psiElement)
-        context.itemsToShow = func?.parameters
-        return func
+        if (func != null) {
+            val modifier = resolveModifier(func.containingFile)
+            if (modifier != null) {
+                context.itemsToShow = modifier.parameters.toList().takeLast(1).toTypedArray()
+                return modifier
+            } else {
+                context.itemsToShow = func.parameters
+            }
+
+            return func
+        }
+        return null
     }
 
     override fun showParameterInfo(element: PsiElement, context: CreateParameterInfoContext) {
@@ -80,19 +95,13 @@ class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSFunction> {
         context.setCurrentParameter(currentParam)
     }
 
-    override fun updateUI(p: JSFunction?, context: ParameterInfoUIContext) {
+    override fun updateUI(p: JSParameter?, context: ParameterInfoUIContext) {
         var text = ""
         if (p == null) {
             return
         }
-        val modifier = resolveModifier(p.containingFile)
-        if (modifier != null) {
-            val param = p.parameters.lastOrNull()
-            param?.jsType
-        }
-        val array = p.parameters.firstOrNull()
-        val hash = p.parameters.lastOrNull()
-        if (array != null) {
+        if (p.jsType is JSArrayType || p.jsType is JSTupleType) {
+            val array = p
             val names = array.children.getOrNull(0)?.children?.map { it.text }
             val type = array.jsType
             if (type is JSTupleType) {
@@ -102,8 +111,8 @@ class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSFunction> {
             }
         }
 
-        if (hash != null) {
-            val type = hash.jsType
+        if (p.jsType is JSRecordType) {
+            val type = p.jsType
             if (type != null) {
                 text += type.resolvedTypeText
             }

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
@@ -1,0 +1,36 @@
+package com.emberjs.hbs
+
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.lang.parameterInfo.*
+import com.intellij.psi.PsiElement
+
+class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, Any> {
+    override fun couldShowInLookup(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun getParametersForLookup(item: LookupElement?, context: ParameterInfoContext?): Array<Any?>? {
+        TODO("Not yet implemented")
+    }
+
+    override fun findElementForParameterInfo(context: CreateParameterInfoContext): PsiElement? {
+        TODO("Not yet implemented")
+    }
+
+    override fun showParameterInfo(element: PsiElement, context: CreateParameterInfoContext) {
+        TODO("Not yet implemented")
+    }
+
+    override fun findElementForUpdatingParameterInfo(context: UpdateParameterInfoContext): PsiElement? {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateParameterInfo(parameterOwner: PsiElement, context: UpdateParameterInfoContext) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateUI(p: Any?, context: ParameterInfoUIContext) {
+        TODO("Not yet implemented")
+    }
+
+}

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
@@ -2,10 +2,7 @@ package com.emberjs.hbs
 
 import com.dmarcotte.handlebars.parsing.HbTokenTypes
 import com.dmarcotte.handlebars.psi.HbParam
-import com.emberjs.utils.findFirstHbsParamFromParam
-import com.emberjs.utils.followReferences
-import com.emberjs.utils.resolveHelper
-import com.emberjs.utils.resolveModifier
+import com.emberjs.utils.*
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.lang.javascript.psi.*
 import com.intellij.lang.javascript.psi.types.JSArrayType
@@ -49,12 +46,10 @@ class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, Any?> {
         }
         val func = resolveHelper(ref.containingFile)
         if (func == null) {
-            val modifier = resolveModifier(ref.containingFile)
-            if (modifier.filterNotNull().isNotEmpty()) {
+            val modifier = resolveDefaultModifier(ref.containingFile)
+            if (modifier != null) {
                 val args = emptyList<Any>().toMutableList()
-                val argType = modifier.first()?.parameters?.getOrNull(2)?.jsType
-                        ?: modifier[1]?.parameters?.getOrNull(1)?.jsType
-                        ?: modifier[2]?.parameters?.getOrNull(1)?.jsType
+                val argType = modifier.parameters.last().jsType
                 if (argType is JSRecordType) {
                     val positional = argType.findPropertySignature("positional")
                     if (positional != null) {

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
@@ -1,36 +1,108 @@
 package com.emberjs.hbs
 
+import com.dmarcotte.handlebars.parsing.HbTokenTypes
+import com.dmarcotte.handlebars.psi.HbParam
+import com.emberjs.utils.resolveHelper
+import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.lang.javascript.psi.JSFunction
+import com.intellij.lang.javascript.psi.JSParameterListElement
+import com.intellij.lang.javascript.psi.types.JSTupleType
 import com.intellij.lang.parameterInfo.*
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parents
+import com.intellij.refactoring.suggested.startOffset
+import org.jetbrains.annotations.NotNull
 
-class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, Any> {
+class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSFunction> {
     override fun couldShowInLookup(): Boolean {
-        TODO("Not yet implemented")
+        return true
     }
 
-    override fun getParametersForLookup(item: LookupElement?, context: ParameterInfoContext?): Array<Any?>? {
-        TODO("Not yet implemented")
+    override fun getParametersForLookup(item: LookupElement?, context: ParameterInfoContext?): Array<JSParameterListElement>? {
+        val psiElement = context?.file?.findElementAt(context.offset)
+        val helperElement = psiElement?.parents
+                ?.find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN_SEXPR }
+                ?:
+                psiElement?.parents
+                        ?.find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN_BLOCK }
+        if (helperElement == null) {
+            return null
+        }
+
+        val file = helperElement.children.getOrNull(1)?.children?.getOrNull(0)?.references?.getOrNull(0)?.resolve()?.containingFile
+        if (file == null) {
+            return null
+        }
+        return resolveHelper(file)?.parameters
     }
 
-    override fun findElementForParameterInfo(context: CreateParameterInfoContext): PsiElement? {
-        TODO("Not yet implemented")
+    private fun findHelperFunction(psiElement: PsiElement?): JSFunction? {
+        val helperElement = psiElement?.parents
+                ?.find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN_SEXPR }
+                ?:
+                psiElement?.parents
+                        ?.find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN_BLOCK }
+        if (helperElement == null) {
+            return null
+        }
+
+        val file = helperElement.children.getOrNull(1)?.children?.getOrNull(0)?.references?.getOrNull(0)?.resolve()?.containingFile
+        if (file == null) {
+            return null
+        }
+        return resolveHelper(file)
+    }
+
+    override fun findElementForParameterInfo(context: CreateParameterInfoContext): JSFunction? {
+        val psiElement = context.file.findElementAt(context.offset)
+        return findHelperFunction(psiElement)
     }
 
     override fun showParameterInfo(element: PsiElement, context: CreateParameterInfoContext) {
-        TODO("Not yet implemented")
+        context.showHint(element, element.textOffset, this)
     }
 
     override fun findElementForUpdatingParameterInfo(context: UpdateParameterInfoContext): PsiElement? {
-        TODO("Not yet implemented")
+        val psiElement = context.file.findElementAt(context.offset)
+        return findHelperFunction(psiElement)
     }
 
     override fun updateParameterInfo(parameterOwner: PsiElement, context: UpdateParameterInfoContext) {
-        TODO("Not yet implemented")
+        val psiElement = context.file.findElementAt(context.offset)
+        if (psiElement == null) {
+            return
+        }
+        val currentParam = psiElement.parent.children.filter { it is HbParam }.indexOf(psiElement) - 1
+        context.setCurrentParameter(currentParam)
     }
 
-    override fun updateUI(p: Any?, context: ParameterInfoUIContext) {
-        TODO("Not yet implemented")
+    override fun updateUI(p: JSFunction?, context: ParameterInfoUIContext) {
+        var text = ""
+        val array = p?.parameters?.firstOrNull()
+        val hash = p?.parameters?.lastOrNull()
+        if (array != null) {
+            val names = array.children.getOrNull(0)?.children?.map { it.text }
+            val type = array.jsType
+            if (type is JSTupleType) {
+                text += names.mapIndexed { index, s -> "$s:${type.getTypeByIndex(index) ?: "unknown"}" }
+            } else {
+                text += "params:" + (array.jsType?.resolvedTypeText ?: "*")
+            }
+        }
+
+        if (hash != null) {
+            val type = hash.jsType
+            if (type != null) {
+                text += type.resolvedTypeText
+            }
+        }
+
+        if (text == "") {
+            return
+        }
+        context.setupUIComponentPresentation(text, -1, -1, false, false, false, context.defaultParameterColor)
     }
 
 }

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
@@ -60,7 +60,7 @@ class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSParameter> {
         return if (file is PsiFile) resolveHelper(file) else if (file is JSFunction) file else null
     }
 
-    override fun findElementForParameterInfo(context: CreateParameterInfoContext): JSFunction? {
+    override fun findElementForParameterInfo(context: CreateParameterInfoContext): PsiElement? {
         val psiElement = context.file.findElementAt(context.offset)
         val func = findHelperFunction(psiElement)
         if (func != null) {
@@ -72,7 +72,7 @@ class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSParameter> {
                 context.itemsToShow = func.parameters
             }
 
-            return func
+            return psiElement
         }
         return null
     }

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
@@ -14,14 +14,15 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.util.elementType
 import com.intellij.psi.util.parents
+import org.jetbrains.annotations.NotNull
 
 
-class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSParameter?> {
+class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSParameterListElement?> {
     override fun couldShowInLookup(): Boolean {
         return true
     }
 
-    override fun getParametersForLookup(item: LookupElement?, context: ParameterInfoContext?): Array<JSParameter>? {
+    override fun getParametersForLookup(item: LookupElement?, context: ParameterInfoContext?): Array<JSParameterListElement>? {
         val psiElement = context?.file?.findElementAt(context.offset)
         val helperElement = psiElement?.parents
                 ?.find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN_SEXPR }
@@ -36,7 +37,7 @@ class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSParameter?> {
         if (file == null) {
             return null
         }
-        return resolveHelper(file)?.parameterVariables
+        return resolveHelper(file)?.parameters
     }
 
     private fun findHelperFunction(psiElement: PsiElement?): JSFunction? {
@@ -60,10 +61,10 @@ class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSParameter?> {
         if (func != null) {
             val modifier = resolveModifier(func.containingFile)
             if (modifier != null) {
-                context.itemsToShow = modifier.parameterVariables.toList().takeLast(1).toTypedArray()
+                context.itemsToShow = modifier.parameters.toList().takeLast(1).toTypedArray()
                 return modifier
             } else {
-                context.itemsToShow = func.parameterVariables
+                context.itemsToShow = func.parameters
             }
 
             return psiElement
@@ -89,7 +90,7 @@ class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, JSParameter?> {
         context.setCurrentParameter(currentParam)
     }
 
-    override fun updateUI(p: JSParameter?, context: ParameterInfoUIContext) {
+    override fun updateUI(p: JSParameterListElement?, context: ParameterInfoUIContext) {
         var text = ""
         if (p == null) {
             return

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
@@ -12,6 +12,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.util.elementType
 import com.intellij.psi.util.parents
 import com.intellij.refactoring.suggested.endOffset
+import com.intellij.refactoring.suggested.startOffset
 import java.util.*
 
 
@@ -33,13 +34,15 @@ class HbsParameterNameHints : InlayParameterHintsProvider  {
                 val array = func?.parameters?.first()
                 val names = array?.children?.getOrNull(0)?.children?.map { it.text }
                 val type = array?.jsType
+                val index = helperElement.parent.children.filter { it is HbParam }.indexOfFirst { it.text == psiElement.text }
                 if (type is JSTupleType) {
-                    val index = helperElement.parent.children.filter { it is HbParam }.indexOfFirst { it.text == psiElement.text }
                     val indexType = type.getTypeByIndex(index)
                     val name = names?.get(index) ?: "unknown"
                     if (indexType != null) {
-                        return mutableListOf(InlayInfo(name+':'+indexType.typeText, psiElement.endOffset))
+                        return mutableListOf(InlayInfo("$name:", psiElement.startOffset))
                     }
+                } else {
+                    return mutableListOf(InlayInfo("param[$index]", psiElement.startOffset))
                 }
             }
             return emptyList<InlayInfo>().toMutableList()

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
@@ -1,0 +1,65 @@
+package com.emberjs.hbs
+
+import com.dmarcotte.handlebars.parsing.HbTokenTypes
+import com.dmarcotte.handlebars.psi.HbParam
+import com.emberjs.utils.resolveHelper
+import com.intellij.codeInsight.hints.HintInfo
+import com.intellij.codeInsight.hints.InlayInfo
+import com.intellij.codeInsight.hints.InlayParameterHintsProvider
+import com.intellij.codeInsight.hints.Option
+import com.intellij.lang.javascript.psi.types.JSTupleType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parents
+import com.intellij.refactoring.suggested.endOffset
+import java.util.*
+
+
+class HbsParameterNameHints : InlayParameterHintsProvider  {
+
+    override fun getParameterHints(psiElement: PsiElement): MutableList<InlayInfo> {
+        if (psiElement is HbParam) {
+            val helperElement = psiElement.parents
+                    .find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN_SEXPR }
+                    ?:
+                    psiElement.parents
+                            .find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN_BLOCK }
+            if (helperElement == null) {
+                return emptyList<InlayInfo>().toMutableList()
+            }
+            val file = helperElement.children.getOrNull(0)?.references?.getOrNull(0)?.resolve()?.containingFile
+            if (file != null) {
+                val func = resolveHelper(file)
+                val array = func?.parameters?.first()
+                val names = array?.children?.getOrNull(0)?.children?.map { it.text }
+                val type = array?.jsType
+                if (type is JSTupleType) {
+                    val index = helperElement.parent.children.filter { it is HbParam }.indexOfFirst { it.text == psiElement.text }
+                    val indexType = type.getTypeByIndex(index)
+                    val name = names?.get(index) ?: "unknown"
+                    if (indexType != null) {
+                        return mutableListOf(InlayInfo(name+':'+indexType.typeText, psiElement.endOffset))
+                    }
+                }
+            }
+            return emptyList<InlayInfo>().toMutableList()
+        }
+        return emptyList<InlayInfo>().toMutableList()
+    }
+
+    override fun getHintInfo(element: PsiElement): HintInfo? {
+        return null
+    }
+
+    override fun getDefaultBlackList(): MutableSet<String> {
+        return Collections.emptySet()
+    }
+
+    override fun getSupportedOptions(): List<Option?> {
+        return Collections.emptyList()
+    }
+
+    override fun isBlackListSupported(): Boolean {
+        return false
+    }
+}

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
@@ -1,14 +1,16 @@
 package com.emberjs.hbs
 
 import com.dmarcotte.handlebars.parsing.HbTokenTypes
+import com.dmarcotte.handlebars.psi.HbMustacheName
 import com.dmarcotte.handlebars.psi.HbParam
 import com.emberjs.utils.followReferences
 import com.emberjs.utils.resolveHelper
+import com.emberjs.utils.resolveModifier
 import com.intellij.codeInsight.hints.HintInfo
 import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.codeInsight.hints.InlayParameterHintsProvider
 import com.intellij.codeInsight.hints.Option
-import com.intellij.lang.javascript.psi.JSFunction
+import com.intellij.lang.javascript.psi.*
 import com.intellij.lang.javascript.psi.types.JSTupleType
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -27,33 +29,59 @@ class HbsParameterNameHints : InlayParameterHintsProvider  {
                     .find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN_SEXPR }
                     ?:
                     psiElement.parents
-                            .find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN_BLOCK }
+                            .find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN }
             if (helperBlock == null) {
                 return emptyList<InlayInfo>().toMutableList()
             }
-            val index = helperBlock.children.filter { it is HbParam }.indexOfFirst { it.text == psiElement.text }
-            if (index <= 0) {
+            var index = helperBlock.children.filter { it is HbParam }.indexOfFirst { it.text == psiElement.text }
+            val helperElement = helperBlock.children.getOrNull(1)?.children?.getOrNull(0)
+            val modifierElement = helperBlock.children.getOrNull(1)
+            if (index <= 0 && modifierElement !is HbMustacheName) {
                 // if its the helper itself
                 return emptyList<InlayInfo>().toMutableList()
+            } else {
+                index += 1
             }
 
-            val helperElement = helperBlock.children.getOrNull(1)?.children?.getOrNull(0)
-            val file = followReferences(helperElement)
+
+            var file = followReferences(helperElement)
+            if (file == helperElement) {
+                file = followReferences(modifierElement)
+            }
+
             if (file != null) {
-                val func = if (file is PsiFile) resolveHelper(file) else if (file is JSFunction) file else null
-                val array = func?.parameters?.first()
-                val names = array?.children?.getOrNull(0)?.children?.map { it.text }
-                val type = array?.jsType
-                if (type is JSTupleType) {
-                    val name = names?.getOrNull(index-1) ?: "unknown"
-                    return mutableListOf(InlayInfo(name, psiElement.startOffset))
+                var func = if (file is PsiFile) resolveHelper(file) else if (file is JSFunction) file else null
+                var arrayName: String? = null
+                var array: JSType? =  null
+
+                if (func != null) {
+                    arrayName = func.parameters.first().name ?: arrayName
+                    array = func.parameters.first().jsType
                 } else {
-                    if (index == 0 && array?.name != null) {
-                        return mutableListOf(InlayInfo(array.name!!, psiElement.startOffset))
+                    val modifier = resolveModifier(file.containingFile)
+                    if (modifier != null) {
+                        val args = modifier.parameters.lastOrNull()?.inferredType
+                        array = null
+                        if (args is JSRecordType) {
+                            array = args.findPropertySignature("positional")?.jsType
+                            arrayName = "positional"
+                        }
                     }
                 }
+
+                val type = array
+                if (type is JSTupleType && type.sourceElement != null) {
+                    val name = type.sourceElement!!.children.map { it.text }.getOrNull(index-1)
+                    if (name != null) {
+                        return mutableListOf(InlayInfo(name, psiElement.startOffset))
+                    } else {
+                        if (index == 1 && arrayName != null) {
+                            return mutableListOf(InlayInfo(arrayName, psiElement.startOffset))
+                        }
+                    }
+
+                }
             }
-            return emptyList<InlayInfo>().toMutableList()
         }
         return emptyList<InlayInfo>().toMutableList()
     }

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
@@ -3,10 +3,7 @@ package com.emberjs.hbs
 import com.dmarcotte.handlebars.parsing.HbTokenTypes
 import com.dmarcotte.handlebars.psi.HbMustacheName
 import com.dmarcotte.handlebars.psi.HbParam
-import com.emberjs.utils.findFirstHbsParamFromParam
-import com.emberjs.utils.followReferences
-import com.emberjs.utils.resolveHelper
-import com.emberjs.utils.resolveModifier
+import com.emberjs.utils.*
 import com.intellij.codeInsight.hints.HintInfo
 import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.codeInsight.hints.InlayParameterHintsProvider
@@ -15,6 +12,8 @@ import com.intellij.lang.javascript.psi.*
 import com.intellij.lang.javascript.psi.types.JSTupleType
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
 import com.intellij.psi.util.parents
 import com.intellij.refactoring.suggested.endOffset
@@ -23,7 +22,7 @@ import java.lang.Integer.max
 import java.util.*
 
 
-class HbsParameterNameHints : InlayParameterHintsProvider  {
+class HbsParameterNameHints : InlayParameterHintsProvider {
 
     override fun getParameterHints(psiElement: PsiElement): MutableList<InlayInfo> {
         if (psiElement is HbParam) {
@@ -35,51 +34,53 @@ class HbsParameterNameHints : InlayParameterHintsProvider  {
                     firstParam.parent.children.filter { it is HbParam }.indexOf(psiElement),
                     firstParam.parent.parent.children.filter { it is HbParam }.indexOf(psiElement)
             )
-            if (index <= 0 && firstParam !is HbMustacheName) {
-                // if its the helper itself
-                return emptyList<InlayInfo>().toMutableList()
-            } else {
+            if (firstParam !is HbParam) {
                 index += 1
             }
-
+            if (index <= 0) {
+                // if its the helper itself
+                return emptyList<InlayInfo>().toMutableList()
+            }
 
             var file = followReferences(firstParam)
             if (file == firstParam) {
-                file = followReferences(firstParam)
-            }
-
-            if (file != null) {
-                var func = if (file is PsiFile) resolveHelper(file) else if (file is JSFunction) file else null
-        var arrayName: String? = null
-        var array: JSType? =  null
-
-        if (func != null) {
-            arrayName = func.parameters.first().name ?: arrayName
-            array = func.parameters.first().jsType
-        } else {
-            val modifier = resolveModifier(file.containingFile)
-            val args = modifier.first()?.parameters?.getOrNull(2)?.jsType
-                    ?: modifier[1]?.parameters?.getOrNull(1)?.jsType
-                    ?: modifier[2]?.parameters?.getOrNull(1)?.jsType
-            array = null
-            if (args is JSRecordType) {
-                array = args.findPropertySignature("positional")?.jsType
-                arrayName = "positional"
-            }
-        }
-
-        val type = array
-        if (type is JSTupleType && type.sourceElement != null) {
-            val name = type.sourceElement!!.children.map { it.text }.getOrNull(index-1)
-            if (name != null) {
-                        return mutableListOf(InlayInfo(name, psiElement.startOffset))
-            } else {
-                if (index == 1 && arrayName != null) {
-                    return mutableListOf(InlayInfo(arrayName, psiElement.startOffset))
+                file = followReferences(firstParam.children[0])
+                if (file == firstParam.children[0]) {
+                    val id = PsiTreeUtil.collectElements(firstParam) { it !is LeafPsiElement && it.elementType == HbTokenTypes.ID }.lastOrNull()
+                    file = followReferences(id, psiElement.text)
                 }
             }
 
-            }
+            if (file != null) {
+                var func = resolveHelper(file.containingFile)
+                var arrayName: String? = null
+                var array: JSType? = null
+
+                if (func != null) {
+                    arrayName = func.parameters.first().name ?: arrayName
+                    array = func.parameters.first().jsType
+                } else {
+                    val modifier = resolveDefaultModifier(file.containingFile)
+                    val args = modifier?.parameters?.lastOrNull()?.jsType
+                    array = null
+                    if (args is JSRecordType) {
+                        array = args.findPropertySignature("positional")?.jsType
+                        arrayName = "positional"
+                    }
+                }
+
+                val type = array
+                if (type is JSTupleType && type.sourceElement != null) {
+                    val name = type.sourceElement!!.children.map { it.text }.getOrNull(index - 1)
+                    if (name != null) {
+                        return mutableListOf(InlayInfo(name, psiElement.startOffset))
+                    } else {
+                        if (index == 1 && arrayName != null) {
+                            return mutableListOf(InlayInfo(arrayName, psiElement.startOffset))
+                        }
+                    }
+
+                }
             }
         }
         return emptyList<InlayInfo>().toMutableList()

--- a/src/main/kotlin/com/emberjs/hbs/HbsPatterns.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsPatterns.kt
@@ -2,12 +2,9 @@ package com.emberjs.hbs
 
 import com.dmarcotte.handlebars.parsing.HbTokenTypes
 import com.dmarcotte.handlebars.psi.*
-import com.dmarcotte.handlebars.psi.impl.HbPathImpl
-import com.intellij.patterns.ElementPattern
 import com.intellij.patterns.PlatformPatterns.psiElement
 import com.intellij.patterns.PsiElementPattern.Capture
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiWhiteSpace
 
 object HbsPatterns {
@@ -39,10 +36,13 @@ object HbsPatterns {
             .withSuperParent(3, SUB_EXPR_NAME)
 
     val MUSTACHE_ID: Capture<PsiElement> = psiElement(HbTokenTypes.ID)
-    val IMPORT_PATH: Capture<PsiElement> = psiElement(HbTokenTypes.STRING)
-            .withParent(psiElement(HbMustacheName::class.java).withName("import"))
+    val IMPORT_PATH_AUTOCOMPLETE: Capture<PsiElement> = psiElement(HbTokenTypes.STRING).withSuperParent(3, (psiElement(HbTokenTypes.PARAM).afterSiblingSkipping(psiElement(HbTokenTypes.WHITE_SPACE), psiElement(HbTokenTypes.PARAM).withText("from"))))
+    val IMPORT_PATH_REF: Capture<PsiElement> = psiElement(HbTokenTypes.STRING).withSuperParent(2, (psiElement(HbTokenTypes.PARAM).afterSiblingSkipping(psiElement(HbTokenTypes.WHITE_SPACE), psiElement(HbTokenTypes.PARAM).withText("from"))))
 
-    val IMPORT_NAMES: Capture<PsiElement> = psiElement(HbTokenTypes.STRING).afterSibling(psiElement(HbParam::class.java).withName("import"))
+    val IMPORT_NAMES: Capture<PsiElement> = psiElement(HbTokenTypes.PARAM)
+            .afterSiblingSkipping(psiElement(HbTokenTypes.WHITE_SPACE),
+                    psiElement(HbTokenTypes.MUSTACHE_NAME).withText("import").afterSibling(psiElement(HbTokenTypes.OPEN))
+            )
 
 
     val STRING_PARAM: Capture<HbParam> = psiElement(HbParam::class.java)

--- a/src/main/kotlin/com/emberjs/hbs/HbsPatterns.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsPatterns.kt
@@ -3,6 +3,7 @@ package com.emberjs.hbs
 import com.dmarcotte.handlebars.parsing.HbTokenTypes
 import com.dmarcotte.handlebars.psi.*
 import com.dmarcotte.handlebars.psi.impl.HbPathImpl
+import com.intellij.patterns.ElementPattern
 import com.intellij.patterns.PlatformPatterns.psiElement
 import com.intellij.patterns.PsiElementPattern.Capture
 import com.intellij.psi.PsiElement
@@ -38,6 +39,11 @@ object HbsPatterns {
             .withSuperParent(3, SUB_EXPR_NAME)
 
     val MUSTACHE_ID: Capture<PsiElement> = psiElement(HbTokenTypes.ID)
+    val IMPORT_PATH: Capture<PsiElement> = psiElement(HbTokenTypes.STRING)
+            .withParent(psiElement(HbMustacheName::class.java).withName("import"))
+
+    val IMPORT_NAMES: Capture<PsiElement> = psiElement(HbTokenTypes.STRING).afterSibling(psiElement(HbParam::class.java).withName("import"))
+
 
     val STRING_PARAM: Capture<HbParam> = psiElement(HbParam::class.java)
             .withChild(psiElement(HbMustacheName::class.java)

--- a/src/main/kotlin/com/emberjs/hbs/HbsPatterns.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsPatterns.kt
@@ -2,9 +2,11 @@ package com.emberjs.hbs
 
 import com.dmarcotte.handlebars.parsing.HbTokenTypes
 import com.dmarcotte.handlebars.psi.*
+import com.dmarcotte.handlebars.psi.impl.HbPathImpl
 import com.intellij.patterns.PlatformPatterns.psiElement
 import com.intellij.patterns.PsiElementPattern.Capture
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiErrorElement
 import com.intellij.psi.PsiWhiteSpace
 
 object HbsPatterns {
@@ -22,12 +24,20 @@ object HbsPatterns {
     val BLOCK_MUSTACHE_NAME_ID: Capture<PsiElement> = psiElement(HbTokenTypes.ID)
             .withSuperParent(3, BLOCK_MUSTACHE_NAME)
 
+    val BLOCK_MUSTACHE_PARAM: Capture<PsiElement> = psiElement(HbTokenTypes.ID)
+            .withParent(psiElement(HbTokenTypes.OPEN_BLOCK_STACHE))
+
+    val MUSTACHE_ID_MISSING: Capture<PsiElement> = psiElement(HbTokenTypes.ID).withParent(psiElement(HbPsiElement::class.java)
+            .afterSibling(psiElement(HbTokenTypes.SEP).afterSibling(psiElement(HbTokenTypes.ID))))
+
     val SUB_EXPR_NAME: Capture<HbMustacheName> = psiElement(HbMustacheName::class.java)
             .withParent(psiElement(HbTokenTypes.PARAM)
                     .afterLeaf(psiElement(HbTokenTypes.OPEN_SEXPR)))
 
     val SUB_EXPR_NAME_ID: Capture<PsiElement> = psiElement(HbTokenTypes.ID)
             .withSuperParent(3, SUB_EXPR_NAME)
+
+    val MUSTACHE_ID: Capture<PsiElement> = psiElement(HbTokenTypes.ID)
 
     val STRING_PARAM: Capture<HbParam> = psiElement(HbParam::class.java)
             .withChild(psiElement(HbMustacheName::class.java)

--- a/src/main/kotlin/com/emberjs/hbs/HbsReferenceContributor.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsReferenceContributor.kt
@@ -5,13 +5,24 @@ import com.intellij.patterns.ElementPattern
 import com.intellij.psi.*
 import com.intellij.util.ProcessingContext
 
+fun filter(element: PsiElement, fn: (PsiElement) -> PsiReference?): PsiReference? {
+    if (element.text.contains(".")) {
+        return null
+    }
+    if (toLocalReference(element) != null) {
+        return null
+    }
+    return fn(element)
+}
+
 class HbsReferenceContributor : PsiReferenceContributor() {
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
         with(registrar) {
-            register(HbsPatterns.SIMPLE_MUSTACHE_NAME) { HbsComponentReference(it) }
-            register(HbsPatterns.BLOCK_MUSTACHE_NAME) { HbsComponentReference(it) }
-            register(HbsPatterns.SIMPLE_MUSTACHE_NAME) { HbsModuleReference(it, "helper") }
-            register(HbsPatterns.SUB_EXPR_NAME) { HbsModuleReference(it, "helper") }
+            register(HbsPatterns.SIMPLE_MUSTACHE_NAME) { filter(it) { HbsComponentReference(it) } }
+            register(HbsPatterns.BLOCK_MUSTACHE_NAME) { filter(it) { HbsComponentReference(it) } }
+            register(HbsPatterns.MUSTACHE_ID) { toLocalReference(it) }
+            register(HbsPatterns.SIMPLE_MUSTACHE_NAME) { filter(it) { HbsModuleReference(it, "helper") } }
+            register(HbsPatterns.SUB_EXPR_NAME) { filter(it) { HbsModuleReference(it, "helper") } }
             registerReferenceProvider(HbsPatterns.LINK_TO_BLOCK_TARGET, HbsLinkToReferenceProvider())
             registerReferenceProvider(HbsPatterns.LINK_TO_SIMPLE_TARGET, HbsLinkToReferenceProvider())
             registerReferenceProvider(HbsPatterns.TRANSLATION_KEY, EmberTranslationHbsReferenceProvider())
@@ -19,9 +30,9 @@ class HbsReferenceContributor : PsiReferenceContributor() {
         }
     }
 
-    private fun PsiReferenceRegistrar.register(pattern: ElementPattern<out PsiElement>, fn: (PsiElement) -> PsiReference) {
+    private fun PsiReferenceRegistrar.register(pattern: ElementPattern<out PsiElement>, fn: (PsiElement) -> PsiReference?) {
         registerReferenceProvider(pattern, object : PsiReferenceProvider() {
-            override fun getReferencesByElement(element: PsiElement, context: ProcessingContext) = arrayOf(fn(element))
+            override fun getReferencesByElement(element: PsiElement, context: ProcessingContext) = arrayOf(fn(element)).filterNotNull().toTypedArray()
         })
     }
 }

--- a/src/main/kotlin/com/emberjs/hbs/HbsReferenceContributor.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsReferenceContributor.kt
@@ -22,7 +22,9 @@ class HbsReferenceContributor : PsiReferenceContributor() {
             register(HbsPatterns.BLOCK_MUSTACHE_NAME) { filter(it) { HbsComponentReference(it) } }
             register(HbsPatterns.MUSTACHE_ID) { toLocalReference(it) }
             register(HbsPatterns.SIMPLE_MUSTACHE_NAME) { filter(it) { HbsModuleReference(it, "helper") } }
+            register(HbsPatterns.SIMPLE_MUSTACHE_NAME) { filter(it) { HbsModuleReference(it, "modifier") } }
             register(HbsPatterns.SUB_EXPR_NAME) { filter(it) { HbsModuleReference(it, "helper") } }
+            register(HbsPatterns.SUB_EXPR_NAME) { filter(it) { HbsModuleReference(it, "modifier") } }
             registerReferenceProvider(HbsPatterns.LINK_TO_BLOCK_TARGET, HbsLinkToReferenceProvider())
             registerReferenceProvider(HbsPatterns.LINK_TO_SIMPLE_TARGET, HbsLinkToReferenceProvider())
             registerReferenceProvider(HbsPatterns.TRANSLATION_KEY, EmberTranslationHbsReferenceProvider())

--- a/src/main/kotlin/com/emberjs/hbs/HbsReferenceContributor.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsReferenceContributor.kt
@@ -1,9 +1,20 @@
 package com.emberjs.hbs
 
+import com.dmarcotte.handlebars.psi.HbMustache
+import com.dmarcotte.handlebars.psi.HbParam
+import com.emberjs.index.EmberNameIndex
 import com.emberjs.translations.EmberTranslationHbsReferenceProvider
+import com.emberjs.utils.*
+import com.intellij.openapi.util.TextRange
 import com.intellij.patterns.ElementPattern
+import com.intellij.patterns.PlatformPatterns
+import com.intellij.patterns.PsiElementPattern
+import com.intellij.patterns.XmlTagPattern
 import com.intellij.psi.*
+import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.xml.XmlAttribute
 import com.intellij.util.ProcessingContext
+import com.sun.deploy.xml.XMLAttribute
 
 fun filter(element: PsiElement, fn: (PsiElement) -> PsiReference?): PsiReference? {
     if (element.text.contains(".")) {
@@ -15,18 +26,119 @@ fun filter(element: PsiElement, fn: (PsiElement) -> PsiReference?): PsiReference
     return fn(element)
 }
 
+class RangedReference(element: PsiElement, val target: PsiElement?, val range: TextRange) : PsiReferenceBase<PsiElement>(element) {
+    override fun resolve(): PsiElement? {
+        return target
+    }
+
+    override fun getRangeInElement(): TextRange {
+        return range
+    }
+}
+
+class ImportPathReferencesProvider : PsiReferenceProvider() {
+    override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<RangedReference> {
+        val psiManager: PsiManager by lazy { PsiManager.getInstance(element.project) }
+        val path = element.text.substring(1, element.text.lastIndex)
+        var resolvedFile: PsiFileSystemItem? = element.originalElement.containingFile.parent
+        var parts = path.split("/")
+        if (path.startsWith("~")) {
+            resolvedFile = psiManager.findDirectory(element.originalVirtualFile!!.parentEmberModule!!)
+        }
+        if (!path.startsWith("~") && !path.startsWith(".")) {
+            resolvedFile = psiManager.findDirectory(element.originalVirtualFile!!.parentEmberModule!!)
+            resolvedFile = resolvedFile?.findSubdirectory("node_modules")
+        }
+        val files = parts.mapIndexed { index, s ->
+            if (s == "." || s == "~") {
+                // do nothing
+            }
+            else if (s == "..") {
+                resolvedFile = resolvedFile?.parent
+            } else {
+                if (resolvedFile is PsiDirectory) {
+                    var dir = resolvedFile as PsiDirectory?
+                    if (resolvedFile!!.virtualFile.isEmberAddonFolder || resolvedFile!!.virtualFile.isEmberFolder) {
+                        dir = dir?.findSubdirectory("addon") ?: dir?.findSubdirectory("app")
+                    }
+                    resolvedFile = dir?.findSubdirectory(s) ?: dir?.children?.find { it is PsiFile && it.name.split(".").first() == s } as PsiFileSystemItem?
+                            ?: resolvedFile
+                } else {
+                    resolvedFile = null
+                }
+            }
+            resolvedFile
+        }.toMutableList()
+
+        val file: PsiFile?
+        if (resolvedFile is PsiDirectory) {
+            val resolvedPath = resolvedFile!!.virtualFile.path.replace("addon/", "").replace("app/", "")
+            val scope = GlobalSearchScope.allScope(element.project)
+            file = EmberNameIndex.getFilteredKeys(scope) { it.importPath.isNotBlank() && resolvedPath.endsWith(it.importPath) }
+                    // Filter out files that are not related to this project
+                    .flatMap { EmberNameIndex.getContainingFiles(it, scope) }
+                    .map { psiManager.findFile(it) }
+                    .firstOrNull()
+        } else {
+            file = resolvedFile as PsiFile?
+        }
+        files[files.lastIndex] = file ?: files.last()
+        return files.mapIndexed() { index, it ->
+            val p = parts.subList(0, index).joinToString("/")
+            var offset = 0
+            if (p.length == 0) {
+                offset = 1
+            } else {
+                offset = p.length + 2
+            }
+            val range = TextRange(offset, offset + parts[index].length)
+            RangedReference(element, it, range)
+        }.toTypedArray()
+    }
+}
+
+class ImportNameReferencesProvider : PsiReferenceProvider() {
+    override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<PsiReference> {
+        val names = element.text.split(",")
+        val named = names.map {
+            if (it.contains(" as ")) {
+                it.split(" as ").first()
+            } else {
+                it
+            }
+        }
+        val mustache = element.parents.find { it is HbMustache }!!
+        val path = mustache.children.findLast { it is HbParam }
+        val fileRef = path?.children?.get(0)?.children?.get(0)?.references?.lastOrNull()?.resolve()
+        if (fileRef is PsiDirectory) {
+            return named
+                    .map { fileRef.findFile(it) ?: fileRef.findSubdirectory(it) }
+                    .filterNotNull()
+                    .map { RangedReference(element, it, TextRange(element.text.indexOf(it.name), it.name.length)) }
+                    .toTypedArray()
+        }
+        if (fileRef == null) {
+            return emptyArray()
+        }
+        val ref = resolveToEmber(fileRef as PsiFile)
+        return arrayOf(RangedReference(element, ref, TextRange(0, element.textLength)))
+    }
+}
+
 class HbsReferenceContributor : PsiReferenceContributor() {
     override fun registerReferenceProviders(registrar: PsiReferenceRegistrar) {
         with(registrar) {
+            registerReferenceProvider(XmlTagPattern.Capture(), TagReferencesProvider())
+            register(PlatformPatterns.psiElement(XmlAttribute::class.java)) { toAttributeReference(it as XmlAttribute) }
             register(HbsPatterns.SIMPLE_MUSTACHE_NAME) { filter(it) { HbsComponentReference(it) } }
             register(HbsPatterns.BLOCK_MUSTACHE_NAME) { filter(it) { HbsComponentReference(it) } }
             register(HbsPatterns.MUSTACHE_ID) { toLocalReference(it) }
-            register(HbsPatterns.IMPORT_NAMES) { toLocalReference(it) }
-            register(HbsPatterns.IMPORT_PATH) { toLocalReference(it) }
             register(HbsPatterns.SIMPLE_MUSTACHE_NAME) { filter(it) { HbsModuleReference(it, "helper") } }
             register(HbsPatterns.SIMPLE_MUSTACHE_NAME) { filter(it) { HbsModuleReference(it, "modifier") } }
             register(HbsPatterns.SUB_EXPR_NAME) { filter(it) { HbsModuleReference(it, "helper") } }
             register(HbsPatterns.SUB_EXPR_NAME) { filter(it) { HbsModuleReference(it, "modifier") } }
+            registerReferenceProvider(HbsPatterns.IMPORT_NAMES, ImportNameReferencesProvider())
+            registerReferenceProvider(HbsPatterns.IMPORT_PATH_REF, ImportPathReferencesProvider())
             registerReferenceProvider(HbsPatterns.LINK_TO_BLOCK_TARGET, HbsLinkToReferenceProvider())
             registerReferenceProvider(HbsPatterns.LINK_TO_SIMPLE_TARGET, HbsLinkToReferenceProvider())
             registerReferenceProvider(HbsPatterns.TRANSLATION_KEY, EmberTranslationHbsReferenceProvider())
@@ -40,3 +152,4 @@ class HbsReferenceContributor : PsiReferenceContributor() {
         })
     }
 }
+

--- a/src/main/kotlin/com/emberjs/hbs/HbsReferenceContributor.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsReferenceContributor.kt
@@ -21,6 +21,8 @@ class HbsReferenceContributor : PsiReferenceContributor() {
             register(HbsPatterns.SIMPLE_MUSTACHE_NAME) { filter(it) { HbsComponentReference(it) } }
             register(HbsPatterns.BLOCK_MUSTACHE_NAME) { filter(it) { HbsComponentReference(it) } }
             register(HbsPatterns.MUSTACHE_ID) { toLocalReference(it) }
+            register(HbsPatterns.IMPORT_NAMES) { toLocalReference(it) }
+            register(HbsPatterns.IMPORT_PATH) { toLocalReference(it) }
             register(HbsPatterns.SIMPLE_MUSTACHE_NAME) { filter(it) { HbsModuleReference(it, "helper") } }
             register(HbsPatterns.SIMPLE_MUSTACHE_NAME) { filter(it) { HbsModuleReference(it, "modifier") } }
             register(HbsPatterns.SUB_EXPR_NAME) { filter(it) { HbsModuleReference(it, "helper") } }

--- a/src/main/kotlin/com/emberjs/hbs/TagReferencesProvider.kt
+++ b/src/main/kotlin/com/emberjs/hbs/TagReferencesProvider.kt
@@ -1,0 +1,156 @@
+package com.emberjs.hbs
+
+import com.dmarcotte.handlebars.parsing.HbTokenTypes
+import com.dmarcotte.handlebars.psi.HbHash
+import com.dmarcotte.handlebars.psi.HbParam
+import com.dmarcotte.handlebars.psi.impl.HbOpenBlockMustacheImpl
+import com.emberjs.index.EmberNameIndex
+import com.emberjs.resolver.ClassOrFileReference
+import com.emberjs.utils.followReferences
+import com.emberjs.utils.referenceImports
+import com.intellij.lang.Language
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.PsiReferenceProvider
+import com.intellij.psi.search.ProjectScope
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parentsWithSelf
+import com.intellij.psi.xml.XmlAttribute
+import com.intellij.psi.xml.XmlTag
+import com.intellij.util.ProcessingContext
+
+/**
+ * this is just to remove leading and trailing `|` from attribute references
+ */
+fun toAttributeReference(attribute: XmlAttribute): RangedReference? {
+    attribute.ownReferences
+    val name = attribute.name
+    if (name.startsWith("|") || name.endsWith("|")) {
+        var range = TextRange(0, name.length)
+        if (name.startsWith("|")) {
+            range = TextRange(1, range.endOffset)
+        }
+        if (name.endsWith("|")) {
+            range = TextRange(range.startOffset, range.endOffset - 1)
+        }
+        return RangedReference(attribute, attribute.descriptor!!.declaration!!, range)
+    }
+    return null
+}
+
+
+class TagReference(element: PsiElement, val target: PsiElement?, val range: TextRange) : PsiReferenceBase<PsiElement>(element) {
+    override fun resolve(): PsiElement? {
+        return target
+    }
+
+    override fun getRangeInElement(): TextRange {
+        return range
+    }
+}
+
+class TagReferencesProvider : PsiReferenceProvider() {
+    fun fromLocalBlock(tag: XmlTag, fullName: String): PsiElement? {
+        val name = fullName.split(".").first()
+        // find html blocks with attribute |name|
+        var refPsi: PsiElement? = null
+        val angleBracketBlock: XmlTag? = tag.parentsWithSelf
+                .find {
+                    it is XmlTag && it.attributes.find {
+                        it.text.startsWith("|") && it.text.replace("|", "").split(" ").contains(name)
+                    } != null
+                } as XmlTag?
+
+        if (angleBracketBlock != null) {
+            refPsi = angleBracketBlock.attributes.find {
+                it.text.startsWith("|") && it.text.replace("|", "").split(" ").contains(name)
+            }
+        }
+
+        // find mustache block |params| which has tag as a child
+        val hbsView = tag.containingFile.viewProvider.getPsi(Language.findLanguageByID("Handlebars")!!)
+        val hbBlockRef = PsiTreeUtil.collectElements(hbsView, { it is HbOpenBlockMustacheImpl })
+                .filter { it.text.contains(Regex("\\|.*$name.*\\|")) }
+                .map { it.parent }
+                .find { block ->
+                    block.textRange.contains(tag.textRange)
+                }
+
+        val param = hbBlockRef?.children?.firstOrNull()?.children?.find { it.elementType == HbTokenTypes.ID && it.text == name}
+        val parts = fullName.split(".")
+        var ref = param ?: refPsi
+        parts.subList(1, parts.size).forEach { part ->
+            ref = followReferences(ref)
+            if (ref is HbParam && ref!!.children[1].text == "hash") {
+                ref = ref!!.children.filter { c -> c is HbHash }.find { c -> (c as HbHash).hashName == part }
+                if (ref is HbHash) {
+                    ref = (ref as HbHash).hashNameElement
+                }
+            }
+        }
+        return followReferences(ref)
+    }
+
+    fun fromImports(tag: XmlTag): PsiElement? {
+        return referenceImports(tag, tag.name.split(".").first())
+    }
+
+    fun forTag(tag: XmlTag?, fullName: String): PsiElement? {
+        if (tag == null) return null
+        val local = fromLocalBlock(tag, fullName) ?: fromImports(tag)
+        if (local != null) {
+            return local
+        }
+
+        val project = tag.project
+        val scope = ProjectScope.getAllScope(project)
+        val psiManager: PsiManager by lazy { PsiManager.getInstance(project) }
+
+        val componentTemplate = // Filter out components that are not related to this project
+                EmberNameIndex.getFilteredKeys(scope) { it.isComponentTemplate && it.tagName == tag.name }
+                        // Filter out components that are not related to this project
+                        .flatMap { EmberNameIndex.getContainingFiles(it, scope) }
+                        .mapNotNull { psiManager.findFile(it) }
+                        .firstOrNull()
+
+        if (componentTemplate != null) return componentTemplate
+
+        val component = EmberNameIndex.getFilteredKeys(scope) { it.type == "component" && it.tagName == tag.name }
+                .flatMap { EmberNameIndex.getContainingFiles(it, scope) }
+                .mapNotNull { psiManager.findFile(it) }
+                .map { ClassOrFileReference(it).resolve() }
+                .firstOrNull()
+
+        if (component != null) return component
+
+        return null
+    }
+    override fun getReferencesByElement(element: PsiElement, context: ProcessingContext): Array<TagReference> {
+        val tag = element as XmlTag
+        val parts = tag.name.split(".")
+        val references = parts.mapIndexed { index, s ->
+            val p = parts.subList(0, index).joinToString(".")
+            val fullName = parts.subList(0, index + 1).joinToString(".")
+            val elem = forTag(tag, fullName)
+            if (elem == null) {
+                return@mapIndexed null
+            }
+
+            var offset = 0
+            if (p.length == 0) {
+                // <
+                offset = 1
+            } else {
+                // < and .
+                offset = p.length + 2
+            }
+
+            val range = TextRange(offset, offset + s.length)
+            TagReference(tag, elem, range)
+        }
+        return references.filterNotNull().toTypedArray()
+    }
+}

--- a/src/main/kotlin/com/emberjs/index/EmberNameKeyDescriptor.kt
+++ b/src/main/kotlin/com/emberjs/index/EmberNameKeyDescriptor.kt
@@ -12,7 +12,7 @@ class EmberNameKeyDescriptor : KeyDescriptor<EmberName> {
     override fun isEqual(val1: EmberName?, val2: EmberName?) = (val1 == val2)
 
     override fun save(storage: DataOutput, value: EmberName) {
-        IOUtil.writeUTF(storage, value.fullName)
+        IOUtil.writeUTF(storage, value.storageKey)
     }
 
     override fun read(storage: DataInput): EmberName? {

--- a/src/main/kotlin/com/emberjs/lookup/HbsInsertHandler.kt
+++ b/src/main/kotlin/com/emberjs/lookup/HbsInsertHandler.kt
@@ -1,0 +1,52 @@
+package com.emberjs.lookup
+
+import com.emberjs.PathKey
+import com.emberjs.hbs.HbsLocalReference
+import com.emberjs.utils.originalVirtualFile
+import com.emberjs.utils.parentModule
+import com.intellij.codeInsight.completion.InsertHandler
+import com.intellij.codeInsight.completion.InsertionContext
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.psi.util.PsiTreeUtil
+
+class HbsInsertHandler : InsertHandler<LookupElement> {
+
+    override fun handleInsert(context: InsertionContext, item: LookupElement) {
+        if (PsiTreeUtil.collectElements(item.psiElement) { it.references.find { it is HbsLocalReference } != null }.size > 0) {
+            return
+        }
+        if (context.project.projectFile?.parentModule?.findChild("node_modules")?.findChild("ember-template-imports") == null) {
+            return
+        }
+        val path = item.getUserData(PathKey)
+        val fullName = item.lookupString.replace("::", "/")
+        val name = fullName.split("/").last()
+        val pattern = "\\{\\{\\s*import\\s+([\\w*\"']+[-,\\w*\\n'\" ]+)\\s+from\\s+['\"]([^'\"]+)['\"]\\s*\\}\\}"
+        val matches = Regex(pattern).findAll(context.document.text)
+        val importsSq = matches.map {
+            it.groups.filterNotNull().map { it.value }.toMutableList().takeLast(2).toMutableList()
+        }
+        val imports = importsSq.asIterable().toMutableList()
+        val m = imports.indexOfFirst { it.last() == path }
+
+        if (m != -1) {
+            val groups = imports.elementAt(m)
+            if (groups.first().contains(name)) return
+            val g = groups.elementAt(0).replace("'", "").replace("\"", "")
+            groups.removeAt(0)
+            groups[0] = "'$g,$name'"
+        } else {
+            val l = arrayOf(name, path!!)
+            imports.add(l.toMutableList())
+        }
+        var text = context.document.text
+        text = text.replace(Regex("$pattern.*\n"), "")
+        for (imp in imports.reversed()) {
+            val l = arrayOf("{{import", imp.elementAt(0), "from '${imp.elementAt(1)}'}}")
+            text = l.joinToString(" ") + "\n" + text
+        }
+        context.document.setText(text)
+        context.commitDocument()
+    }
+
+}

--- a/src/main/kotlin/com/emberjs/psi/HbsRefactoringSupportProvider.kt
+++ b/src/main/kotlin/com/emberjs/psi/HbsRefactoringSupportProvider.kt
@@ -1,0 +1,14 @@
+package com.emberjs.psi
+
+import com.intellij.lang.refactoring.RefactoringSupportProvider
+import com.intellij.psi.PsiElement
+
+class HbsRefactoringSupportProvider : RefactoringSupportProvider() {
+    override fun isSafeDeleteAvailable(element: PsiElement): Boolean {
+        return false;
+    }
+
+    override fun isMemberInplaceRenameAvailable(element: PsiElement, context: PsiElement?): Boolean {
+        return true;
+    }
+}

--- a/src/main/kotlin/com/emberjs/psi/RenameHbsIdProcessor.kt
+++ b/src/main/kotlin/com/emberjs/psi/RenameHbsIdProcessor.kt
@@ -24,11 +24,11 @@ import kotlin.collections.forEach
 import kotlin.collections.set
 
 
-class RenamePropertyProcessor : RenamePsiElementProcessor() {
+class RenameHbsIdProcessor : RenamePsiElementProcessor() {
     override fun canProcessElement(element: PsiElement): Boolean {
         val mustacheId = element.elementType == HbTokenTypes.ID && element.prevSibling.elementType != HbTokenTypes.SEP
         val htmlBlockParam = element is EmberAttrDec
-        return mustacheId || htmlBlockParam
+        return mustacheId
     }
 
     override fun prepareRenaming(element: PsiElement, newName: String,

--- a/src/main/kotlin/com/emberjs/psi/RenamePropertyProcessor.kt
+++ b/src/main/kotlin/com/emberjs/psi/RenamePropertyProcessor.kt
@@ -1,0 +1,53 @@
+package com.emberjs.psi
+
+import com.dmarcotte.handlebars.parsing.HbTokenTypes
+import com.dmarcotte.handlebars.psi.HbPath
+import com.intellij.openapi.util.Comparing
+import com.intellij.pom.PomTargetPsiElement
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parents
+import com.intellij.refactoring.rename.RenamePsiElementProcessor
+import com.intellij.refactoring.rename.UnresolvableCollisionUsageInfo
+import com.intellij.usageView.UsageInfo
+import com.sun.deploy.xml.XMLAttribute
+import java.util.ResourceBundle
+import kotlin.collections.LinkedHashMap
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.collections.MutableList
+import kotlin.collections.MutableMap
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.forEach
+import kotlin.collections.set
+
+
+class RenamePropertyProcessor : RenamePsiElementProcessor() {
+    override fun canProcessElement(element: PsiElement): Boolean {
+        val mustacheId = element.elementType == HbTokenTypes.ID && element.parent.children.indexOf(element) == 0
+        val htmlBlockParam = element is XMLAttribute && element.text.matches(Regex("\\|.*\\|"))
+        // todo: support html block param rename
+        return mustacheId
+    }
+
+    override fun prepareRenaming(element: PsiElement, newName: String,
+                                 allRenames: MutableMap<PsiElement, String>) {
+        // todo
+    }
+
+    override fun findCollisions(element: PsiElement,
+                                newName: String,
+                                allRenames: Map<out PsiElement, String>,
+                                result: MutableList<UsageInfo>) {
+        // todo
+    }
+
+    override fun isToSearchInComments(element: PsiElement): Boolean {
+        return false
+    }
+
+    override fun setToSearchInComments(element: PsiElement, enabled: Boolean) {
+
+    }
+}

--- a/src/main/kotlin/com/emberjs/psi/RenamePropertyProcessor.kt
+++ b/src/main/kotlin/com/emberjs/psi/RenamePropertyProcessor.kt
@@ -2,6 +2,7 @@ package com.emberjs.psi
 
 import com.dmarcotte.handlebars.parsing.HbTokenTypes
 import com.dmarcotte.handlebars.psi.HbPath
+import com.emberjs.EmberAttrDec
 import com.intellij.openapi.util.Comparing
 import com.intellij.pom.PomTargetPsiElement
 import com.intellij.psi.PsiElement
@@ -26,9 +27,8 @@ import kotlin.collections.set
 class RenamePropertyProcessor : RenamePsiElementProcessor() {
     override fun canProcessElement(element: PsiElement): Boolean {
         val mustacheId = element.elementType == HbTokenTypes.ID && element.prevSibling.elementType != HbTokenTypes.SEP
-        val htmlBlockParam = element is XMLAttribute && element.text.matches(Regex("\\|.*\\|"))
-        // todo: support html block param rename
-        return mustacheId
+        val htmlBlockParam = element is EmberAttrDec
+        return mustacheId || htmlBlockParam
     }
 
     override fun prepareRenaming(element: PsiElement, newName: String,

--- a/src/main/kotlin/com/emberjs/psi/RenamePropertyProcessor.kt
+++ b/src/main/kotlin/com/emberjs/psi/RenamePropertyProcessor.kt
@@ -25,7 +25,7 @@ import kotlin.collections.set
 
 class RenamePropertyProcessor : RenamePsiElementProcessor() {
     override fun canProcessElement(element: PsiElement): Boolean {
-        val mustacheId = element.elementType == HbTokenTypes.ID && element.parent.children.indexOf(element) == 0
+        val mustacheId = element.elementType == HbTokenTypes.ID && element.prevSibling.elementType != HbTokenTypes.SEP
         val htmlBlockParam = element is XMLAttribute && element.text.matches(Regex("\\|.*\\|"))
         // todo: support html block param rename
         return mustacheId

--- a/src/main/kotlin/com/emberjs/refactoring/HbsRefactoringSupportProvider.kt
+++ b/src/main/kotlin/com/emberjs/refactoring/HbsRefactoringSupportProvider.kt
@@ -1,4 +1,4 @@
-package com.emberjs.psi
+package com.emberjs.refactoring
 
 import com.intellij.lang.refactoring.RefactoringSupportProvider
 import com.intellij.psi.PsiElement
@@ -10,5 +10,13 @@ class HbsRefactoringSupportProvider : RefactoringSupportProvider() {
 
     override fun isMemberInplaceRenameAvailable(element: PsiElement, context: PsiElement?): Boolean {
         return true;
+    }
+
+    override fun isInplaceRenameAvailable(element: PsiElement, context: PsiElement?): Boolean {
+        return true;
+    }
+
+    override fun isInplaceIntroduceAvailable(element: PsiElement, context: PsiElement?): Boolean {
+        return true
     }
 }

--- a/src/main/kotlin/com/emberjs/refactoring/HbsRenameHandler.kt
+++ b/src/main/kotlin/com/emberjs/refactoring/HbsRenameHandler.kt
@@ -1,0 +1,24 @@
+package com.emberjs.refactoring
+
+import com.intellij.openapi.actionSystem.DataContext
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.refactoring.rename.RenameHandler
+
+class HbsRenameHandler : RenameHandler {
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?, dataContext: DataContext?) {
+        dataContext
+    }
+
+    override fun invoke(project: Project, elements: Array<out PsiElement>, dataContext: DataContext?) {
+        dataContext
+    }
+
+    override fun isAvailableOnDataContext(dataContext: DataContext): Boolean {
+        dataContext
+        return true
+    }
+
+}

--- a/src/main/kotlin/com/emberjs/refactoring/HbsUsageProvider.kt
+++ b/src/main/kotlin/com/emberjs/refactoring/HbsUsageProvider.kt
@@ -1,0 +1,53 @@
+package com.emberjs.refactoring
+
+import com.dmarcotte.handlebars.parsing.HbLexer
+import com.dmarcotte.handlebars.parsing.HbTokenTypes
+import com.emberjs.EmberAttributeDescriptor
+import com.intellij.lang.cacheBuilder.DefaultWordsScanner
+import com.intellij.lang.cacheBuilder.WordsScanner
+import com.intellij.lang.findUsages.FindUsagesProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.tree.TokenSet
+import com.intellij.psi.util.elementType
+import com.intellij.psi.xml.XmlAttribute
+
+
+class HbsWordScanner : DefaultWordsScanner(HbLexer(), TokenSet.create(HbTokenTypes.ID), HbTokenTypes.COMMENTS, TokenSet.create(HbTokenTypes.NUMBER, HbTokenTypes.BOOLEAN, HbTokenTypes.STRING)) {
+
+}
+
+
+class HbsUsageProvider : FindUsagesProvider {
+
+    override fun getWordsScanner(): WordsScanner? {
+        return null
+    }
+
+    override fun canFindUsagesFor(psiElement: PsiElement): Boolean {
+        return psiElement.elementType == HbTokenTypes.ID ||
+                (psiElement is XmlAttribute
+                        && psiElement.descriptor is EmberAttributeDescriptor
+                        && (psiElement.descriptor as EmberAttributeDescriptor).isParam)
+    }
+
+    override fun getHelpId(psiElement: PsiElement): String? {
+        return "find usages"
+    }
+
+    override fun getType(element: PsiElement): String {
+        return "variable"
+    }
+
+    override fun getDescriptiveName(element: PsiElement): String {
+        return "variable"
+    }
+
+    override fun getNodeText(element: PsiElement, useFullName: Boolean): String {
+        if (element is XmlAttribute) {
+            val range = element.references.last().rangeInElement
+            return element.text.substring(range.startOffset, range.endOffset)
+        }
+        return element.text
+    }
+
+}

--- a/src/main/kotlin/com/emberjs/refactoring/RenameHbsIdProcessor.kt
+++ b/src/main/kotlin/com/emberjs/refactoring/RenameHbsIdProcessor.kt
@@ -1,46 +1,34 @@
-package com.emberjs.psi
+package com.emberjs.refactoring
 
 import com.dmarcotte.handlebars.parsing.HbTokenTypes
-import com.dmarcotte.handlebars.psi.HbPath
 import com.emberjs.EmberAttrDec
-import com.intellij.openapi.util.Comparing
-import com.intellij.pom.PomTargetPsiElement
 import com.intellij.psi.PsiElement
 import com.intellij.psi.util.elementType
-import com.intellij.psi.util.parents
+import com.intellij.refactoring.listeners.RefactoringElementListener
 import com.intellij.refactoring.rename.RenamePsiElementProcessor
-import com.intellij.refactoring.rename.UnresolvableCollisionUsageInfo
 import com.intellij.usageView.UsageInfo
-import com.sun.deploy.xml.XMLAttribute
-import java.util.ResourceBundle
-import kotlin.collections.LinkedHashMap
-import kotlin.collections.List
-import kotlin.collections.Map
-import kotlin.collections.MutableList
-import kotlin.collections.MutableMap
-import kotlin.collections.component1
-import kotlin.collections.component2
-import kotlin.collections.forEach
-import kotlin.collections.set
-
 
 class RenameHbsIdProcessor : RenamePsiElementProcessor() {
     override fun canProcessElement(element: PsiElement): Boolean {
         val mustacheId = element.elementType == HbTokenTypes.ID && element.prevSibling.elementType != HbTokenTypes.SEP
         val htmlBlockParam = element is EmberAttrDec
-        return mustacheId
+        return mustacheId || htmlBlockParam
+    }
+
+    override fun renameElement(element: PsiElement, newName: String, usages: Array<out UsageInfo>, listener: RefactoringElementListener?) {
+        element
     }
 
     override fun prepareRenaming(element: PsiElement, newName: String,
                                  allRenames: MutableMap<PsiElement, String>) {
-        // todo
+        val x = allRenames
     }
 
     override fun findCollisions(element: PsiElement,
                                 newName: String,
                                 allRenames: Map<out PsiElement, String>,
                                 result: MutableList<UsageInfo>) {
-        // todo
+
     }
 
     override fun isToSearchInComments(element: PsiElement): Boolean {

--- a/src/main/kotlin/com/emberjs/resolver/ClassOrFileReference.kt
+++ b/src/main/kotlin/com/emberjs/resolver/ClassOrFileReference.kt
@@ -1,0 +1,33 @@
+package com.emberjs.resolver
+
+import com.intellij.lang.ecmascript6.psi.impl.ES6ClassExpressionImpl
+import com.intellij.lang.ecmascript6.psi.impl.ES6ClassImpl
+import com.intellij.lang.ecmascript6.resolve.ES6PsiUtil
+import com.intellij.lang.javascript.psi.impl.JSReferenceExpressionImpl
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.annotations.NotNull
+
+class ClassOrFileReference(element: @NotNull PsiElement, target: PsiElement?) : PsiReferenceBase<PsiElement>(element) {
+    private val refElement: PsiElement?
+
+    init {
+        val psiExp = ES6PsiUtil.findDefaultExport(target ?: this.element)
+        if (psiExp != null) {
+            var cls: Any? = PsiTreeUtil.findChildOfType(psiExp, ES6ClassExpressionImpl::class.java)
+            if (cls == null) {
+                val ref = PsiTreeUtil.findChildOfType(psiExp, JSReferenceExpressionImpl::class.java)
+                cls = ref?.resolve()
+            }
+            this.refElement = cls as PsiElement?
+        } else {
+            this.refElement = this.element.containingFile
+        }
+    }
+    override fun resolve(): PsiElement? {
+        return this.refElement
+    }
+
+}

--- a/src/main/kotlin/com/emberjs/resolver/ClassOrFileReference.kt
+++ b/src/main/kotlin/com/emberjs/resolver/ClassOrFileReference.kt
@@ -1,5 +1,7 @@
 package com.emberjs.resolver
 
+import com.emberjs.utils.findDefaultExportClass
+import com.emberjs.utils.resolveHelper
 import com.intellij.lang.ecmascript6.psi.impl.ES6ClassExpressionImpl
 import com.intellij.lang.ecmascript6.resolve.ES6PsiUtil
 import com.intellij.lang.javascript.psi.JSCallExpression
@@ -7,6 +9,7 @@ import com.intellij.lang.javascript.psi.JSFunction
 import com.intellij.lang.javascript.psi.impl.JSArgumentListImpl
 import com.intellij.lang.javascript.psi.impl.JSReferenceExpressionImpl
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiReference
 import com.intellij.psi.PsiReferenceBase
 import com.intellij.psi.util.PsiTreeUtil
@@ -14,32 +17,17 @@ import com.intellij.psi.util.PsiTreeUtil
 class ClassOrFileReference(element: PsiElement, target: PsiElement?) : PsiReferenceBase<PsiElement>(element) {
     private val refElement: PsiElement?
 
-    fun resolveHelper(element: PsiElement?): PsiElement? {
-        if (element is PsiReference && element.resolve() != null) {
-            return resolveHelper(element.resolve()!!)
-        }
-        if (element is JSCallExpression && element.text.startsWith("helper(")) {
-            val res = ((element.children[1] as JSArgumentListImpl).arguments[0] as PsiReference).resolve()!!
-            return resolveHelper(res)
-        }
-        if (element is JSFunction) {
-            return element
-        }
-        return null
-    }
-
     init {
-        val psiExp = ES6PsiUtil.findDefaultExport(target ?: this.element)
-        if (psiExp != null) {
-            var cls: Any? = PsiTreeUtil.findChildOfType(psiExp, ES6ClassExpressionImpl::class.java)
-            if (cls == null) {
-                val ref = PsiTreeUtil.findChildOfType(psiExp, JSReferenceExpressionImpl::class.java)
-                cls = ref?.resolve()
-            }
-            // for helpers
-            if (cls == null) {
-                cls = resolveHelper(psiExp.children[0])
-            }
+        var cls: Any? = findDefaultExportClass(target as PsiFile? ?: this.element as PsiFile)
+        if (cls == null) {
+            val ref = PsiTreeUtil.findChildOfType(cls, JSReferenceExpressionImpl::class.java)
+            cls = ref?.resolve()
+        }
+        // for helpers
+        if (cls == null) {
+            cls = resolveHelper(target as PsiFile? ?: this.element as PsiFile)
+        }
+        if (cls != null) {
             this.refElement = cls as PsiElement?
         } else {
             this.refElement = this.element.containingFile

--- a/src/main/kotlin/com/emberjs/resolver/ClassOrFileReference.kt
+++ b/src/main/kotlin/com/emberjs/resolver/ClassOrFileReference.kt
@@ -8,30 +8,32 @@ import com.intellij.lang.javascript.psi.JSCallExpression
 import com.intellij.lang.javascript.psi.JSFunction
 import com.intellij.lang.javascript.psi.impl.JSArgumentListImpl
 import com.intellij.lang.javascript.psi.impl.JSReferenceExpressionImpl
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
-import com.intellij.psi.PsiReference
-import com.intellij.psi.PsiReferenceBase
+import com.intellij.psi.*
 import com.intellij.psi.util.PsiTreeUtil
 
-class ClassOrFileReference(element: PsiElement, target: PsiElement?) : PsiReferenceBase<PsiElement>(element) {
+class ClassOrFileReference(element: PsiElement) : PsiReferenceBase<PsiElement>(element) {
     private val refElement: PsiElement?
 
     init {
-        var cls: Any? = findDefaultExportClass(target as PsiFile? ?: this.element as PsiFile)
-        if (cls == null) {
-            val ref = PsiTreeUtil.findChildOfType(cls, JSReferenceExpressionImpl::class.java)
-            cls = ref?.resolve()
-        }
-        // for helpers
-        if (cls == null) {
-            cls = resolveHelper(target as PsiFile? ?: this.element as PsiFile)
-        }
-        if (cls != null) {
-            this.refElement = cls as PsiElement?
+        if (this.element is PsiFile) {
+            var cls: Any? = findDefaultExportClass(this.element as PsiFile)
+            if (cls == null) {
+                val ref = PsiTreeUtil.findChildOfType(cls, JSReferenceExpressionImpl::class.java)
+                cls = ref?.resolve()
+            }
+            // for helpers
+            if (cls == null) {
+                cls = resolveHelper(this.element as PsiFile)
+            }
+            if (cls != null) {
+                this.refElement = cls as PsiElement?
+            } else {
+                this.refElement = this.element
+            }
         } else {
-            this.refElement = this.element.containingFile
+            this.refElement = this.element
         }
+
     }
     override fun resolve(): PsiElement? {
         return this.refElement

--- a/src/main/kotlin/com/emberjs/resolver/EmberModuleReferenceContributor.kt
+++ b/src/main/kotlin/com/emberjs/resolver/EmberModuleReferenceContributor.kt
@@ -2,6 +2,7 @@ package com.emberjs.resolver
 
 import com.emberjs.cli.EmberCliProjectConfigurator
 import com.emberjs.utils.emberRoot
+import com.emberjs.utils.isEmberAddonFolder
 import com.emberjs.utils.isInRepoAddon
 import com.emberjs.utils.parents
 import com.intellij.lang.ecmascript6.psi.ES6ExportDefaultAssignment
@@ -62,9 +63,13 @@ class EmberModuleReferenceContributor : JSModuleReferenceContributor {
 
         /** Search the `/app` and `/addon` directories of the root and each in-repo-addon */
         val roots = modules
+                .filter { it.isEmberAddonFolder }
                 .flatMap { listOfNotNull(it.findChild("addon"), it.findChild("app"), it.findChild("addon-test-support")) }
                 .map { JSExactFileReference(host, TextRange.create(offset, offset + packageName.length), listOf(it.path), null) }
 
+        if (roots.isEmpty()) {
+            return emptyArray()
+        }
         val refs : FileReferenceSet
         val startInElement = offset + packageName.length + 1
 

--- a/src/main/kotlin/com/emberjs/resolver/EmberModuleReferenceContributor.kt
+++ b/src/main/kotlin/com/emberjs/resolver/EmberModuleReferenceContributor.kt
@@ -4,16 +4,23 @@ import com.emberjs.cli.EmberCliProjectConfigurator
 import com.emberjs.utils.emberRoot
 import com.emberjs.utils.isInRepoAddon
 import com.emberjs.utils.parents
+import com.intellij.lang.ecmascript6.psi.ES6ExportDefaultAssignment
+import com.intellij.lang.ecmascript6.resolve.ES6PsiUtil
 import com.intellij.lang.javascript.DialectDetector
 import com.intellij.lang.javascript.frameworks.amd.JSModuleReference
 import com.intellij.lang.javascript.frameworks.modules.JSExactFileReference
+import com.intellij.lang.javascript.psi.JSFile
+import com.intellij.lang.javascript.psi.impl.JSPsiImplUtils
 import com.intellij.lang.javascript.psi.resolve.JSModuleReferenceContributor
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.*
+import com.intellij.psi.impl.source.PsiFileImpl
 import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReference
 import com.intellij.psi.impl.source.resolve.reference.impl.providers.FileReferenceSet
+import org.jetbrains.annotations.NotNull
 import java.util.regex.Pattern
+
 
 /**
  * Resolves absolute imports from the ember application root, e.g.
@@ -91,7 +98,7 @@ class EmberModuleReferenceContributor : JSModuleReferenceContributor {
             return arrayOf()
         }
 
-        return (roots + refs.allReferences).toTypedArray()
+        return (roots + refs.allReferences).toTypedArray().map { ClassOrFileReference(it.element, null) }.toTypedArray()
     }
 
     override fun isApplicable(host: PsiElement): Boolean = DialectDetector.isES6(host)

--- a/src/main/kotlin/com/emberjs/resolver/EmberModuleReferenceContributor.kt
+++ b/src/main/kotlin/com/emberjs/resolver/EmberModuleReferenceContributor.kt
@@ -62,7 +62,7 @@ class EmberModuleReferenceContributor : JSModuleReferenceContributor {
 
         /** Search the `/app` and `/addon` directories of the root and each in-repo-addon */
         val roots = modules
-                .flatMap { listOfNotNull(it.findChild("app"), it.findChild("addon"), it.findChild("addon-test-support")) }
+                .flatMap { listOfNotNull(it.findChild("addon"), it.findChild("app"), it.findChild("addon-test-support")) }
                 .map { JSExactFileReference(host, TextRange.create(offset, offset + packageName.length), listOf(it.path), null) }
 
         val refs : FileReferenceSet

--- a/src/main/kotlin/com/emberjs/resolver/EmberModuleReferenceContributor.kt
+++ b/src/main/kotlin/com/emberjs/resolver/EmberModuleReferenceContributor.kt
@@ -109,10 +109,8 @@ class EmberModuleReferenceContributor : JSModuleReferenceContributor {
 
         // filter out invalid references
         // reference default export if available, otherwise file
-        return roots.map { it as PsiReference }.toTypedArray() + refs.allReferences
-                .map { it.resolve() }
-                .filterNotNull()
-                .map { ClassOrFileReference(it) as PsiReference }
+        return (roots + refs.allReferences)
+                .filter { it.resolve() != null }
                 .toTypedArray()
     }
 

--- a/src/main/kotlin/com/emberjs/resolver/EmberName.kt
+++ b/src/main/kotlin/com/emberjs/resolver/EmberName.kt
@@ -6,7 +6,19 @@ import com.emberjs.utils.parents
 import com.intellij.openapi.vfs.VfsUtilCore.isAncestor
 import com.intellij.openapi.vfs.VirtualFile
 
-data class EmberName(val type: String, val name: String) {
+data class EmberName(val type: String, val path: String, val importPath: String = "") {
+
+    override fun hashCode(): Int = fullName.hashCode()
+
+    override fun equals(other: Any?): Boolean {
+        return this.hashCode() == other.hashCode()
+    }
+
+    val name by lazy {
+        path
+    }
+
+    val storageKey by lazy { "$type:$name:$importPath" }
 
     val fullName by lazy { "$type:$name" }
 
@@ -39,13 +51,6 @@ data class EmberName(val type: String, val name: String) {
         }
     }
 
-
-    val path by lazy {
-        assert(type == "component" || isComponentTemplate)
-
-        name
-    }
-
     val tagName by lazy {
         assert(type == "component" || isComponentTemplate)
 
@@ -69,10 +74,10 @@ data class EmberName(val type: String, val name: String) {
         private val SIMPLE_DASHERIZE_REGEXP = Regex("[a-z]|/|-")
         private val ALPHA = Regex("[A-Za-z0-9]")
 
-        fun from(fullName: String): EmberName? {
-            val parts = fullName.split(":")
+        fun from(storageKey: String): EmberName? {
+            val parts = storageKey.split(":")
             return when {
-                parts.count() == 2 -> EmberName(parts[0], parts[1])
+                parts.count() >= 2 -> EmberName(parts[0], parts[1], parts.getOrNull(2) ?: "")
                 else -> null
             }
         }
@@ -95,6 +100,44 @@ data class EmberName(val type: String, val name: String) {
             ?: fromAcceptanceTest(acceptanceTestsFolder, file)
         }
 
+        private fun getImportPath(type: EmberFileType, file: VirtualFile): String? {
+            // e.g. private helpers for component
+            if (type == EmberFileType.COMPONENT && file.path.contains("helpers/")) {
+                return null
+            }
+            var path: String
+            if (file.path.contains("node_modules")) {
+                path = file.parents
+                        .takeWhile { it.name != "node_modules" }
+                        .map { it.name }
+                        .reversed()
+                        .joinToString("/")
+            } else {
+                path = file.parents
+                        .takeWhile { it != file.parentEmberModule }
+                        .map { it.name }
+                        .reversed()
+                        .joinToString("/")
+            }
+
+            path = path.replace("/app/", "/")
+            path = path.replace("/addon/", "/")
+            var name = file.nameWithoutExtension.removePrefix("/")
+
+            // detect flat and nested component layout (where hbs file lies in the components/ folder)
+            if (file.extension == "css" || file.extension == "scss") {
+                return "$path/$name"
+            }
+            // if component.js/ts or component.d.ts exists
+            if (file.nameWithoutExtension == "component" || file.name == "component.d.ts") {
+                name = ""
+            }
+            if (file.nameWithoutExtension == "template") {
+                name = ""
+            }
+            return "$path/$name".removeSuffix("/")
+        }
+
         fun fromClassic(appFolder: VirtualFile?, file: VirtualFile): EmberName? {
             appFolder ?: return null
 
@@ -115,47 +158,31 @@ data class EmberName(val type: String, val name: String) {
             return EmberFileType.FOLDER_NAMES[typeFolder.name]?.let { type ->
 
                 // e.g. private helpers for component
-                if (file.path.contains("/helpers")) {
+                if (type == EmberFileType.COMPONENT && file.path.contains("helpers/")) {
                     return null
                 }
-                var path = ""
-                if (file.path.contains("node_modules")) {
-                    path = file.parents
-                            .takeWhile { it.name != "node_modules" }
-                            .map { it.name }
-                            .reversed()
-                            .joinToString("/")
-                } else {
-                    path = file.parents
-                            .takeWhile { it != file.parentEmberModule }
-                            .map { it.name }
-                            .reversed()
-                            .joinToString("/")
+                val path = this.getImportPath(type, file)
+
+                if (path == null) {
+                    return null
                 }
-
-                path = path.replace("/app/", "/")
-                path = path.replace("/addon/", "/")
-
-                var name = file.nameWithoutExtension
-
                 // detect flat and nested component layout (where hbs file lies in the components/ folder)
+
+                val pathFromTypeRoot = path.split("/")
+                        .reversed()
+                        .takeWhile { it != typeFolder.name  }
+                        .reversed()
+                        .joinToString("/")
+
                 if (type == EmberFileType.COMPONENT) {
-                    // if component.d.ts exists
-                    if (file.name.endsWith("component") || file.name.endsWith("component.d.ts")) {
-                        name = ""
-                    }
-                    if (file.name.endsWith("template.hbs")) {
-                        name = ""
+                    if (file.extension == "hbs") {
+                        return EmberName(EmberFileType.TEMPLATE.name.toLowerCase(), "components/$pathFromTypeRoot", path)
                     }
                     if (file.extension == "css" || file.extension == "scss") {
-                        return EmberName("styles", "components/${name.removeSuffix(".module")}")
+                        return EmberName("styles", "components/${pathFromTypeRoot.removeSuffix(".module")}")
                     }
                 }
-                var importPath = path + "/" + name
-                if (importPath.startsWith("app/")) {
-                    importPath = importPath.replace("app/", "~/")
-                }
-                EmberName(type.name.toLowerCase(), importPath.removeSuffix("/"))
+                return EmberName(type.name.toLowerCase(), pathFromTypeRoot, path)
             }
         }
 
@@ -226,7 +253,7 @@ data class EmberName(val type: String, val name: String) {
                                 else -> it
                             }
                         }
-                        .let { EmberName(type.name.toLowerCase(), it) }
+                        .let { EmberName(type.name.toLowerCase(), it,this.getImportPath(type, file) ?: file.path) }
             }
         }
 

--- a/src/main/kotlin/com/emberjs/utils/VirtualFileExtensions.kt
+++ b/src/main/kotlin/com/emberjs/utils/VirtualFileExtensions.kt
@@ -26,12 +26,13 @@ val VirtualFile.parents: Iterable<VirtualFile>
 val cache = HashMap<String, Boolean>()
 
 val VirtualFile.isEmberAddonFolder: Boolean
+
     get() {
         if (cache.contains(this.path)) return cache.getOrDefault(this.path, false)
         val packageJsonFile = findFileByRelativePath("package.json") ?: return false
         var text = ""
         try {
-            text = VfsUtilCore.loadText(packageJsonFile)
+            text = String(packageJsonFile.contentsToByteArray())
         } catch (var3: IOException) {
             return false
         }

--- a/src/main/kotlin/com/emberjs/utils/utils.kt
+++ b/src/main/kotlin/com/emberjs/utils/utils.kt
@@ -13,6 +13,12 @@ import com.intellij.psi.PsiReference
 import com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.annotations.NotNull
 
+fun resolveModifier(file: PsiFile): JSFunction? {
+    val func = resolveHelper(file)
+    val installer: JSFunction? = PsiTreeUtil.collectElements(func.parent, { it is JSFunction && it.name == "installModifier"}).firstOrNull();
+    return installer
+}
+
 fun resolveHelper(file: PsiFile): JSFunction? {
     var exp = ES6PsiUtil.findDefaultExport(file)
     val exportImport = PsiTreeUtil.findChildOfType(file, ES6ImportExportDeclaration::class.java)
@@ -43,9 +49,10 @@ fun findHelperParams(file: PsiFile): Array<JSParameterListElement>? {
 
 fun findDefaultExportClass(file: PsiFile): JSClass? {
     val exp = ES6PsiUtil.findDefaultExport(file)
-    var cls: Any? = PsiTreeUtil.findChildOfType(exp, JSClass::class.java)
+    var cls: Any? = exp?.children?.find { it is JSClass }
+    cls = cls ?: exp?.children?.find { it is JSFunction }
     if (cls == null) {
-        val ref = PsiTreeUtil.findChildOfType(exp, JSReferenceExpression::class.java)
+        val ref = exp?.children?.find { it is JSReferenceExpression }
         cls = ref?.resolve()
         if (cls is JSClass) {
             return cls

--- a/src/main/kotlin/com/emberjs/utils/utils.kt
+++ b/src/main/kotlin/com/emberjs/utils/utils.kt
@@ -15,7 +15,7 @@ import org.jetbrains.annotations.NotNull
 
 fun resolveModifier(file: PsiFile): JSFunction? {
     val func = resolveHelper(file)
-    val installer: JSFunction? = PsiTreeUtil.collectElements(func.parent, { it is JSFunction && it.name == "installModifier"}).firstOrNull();
+    val installer: JSFunction? = PsiTreeUtil.collectElements(func?.parent, { it is JSFunction && it.name == "installModifier"}).firstOrNull() as JSFunction?
     return installer
 }
 

--- a/src/main/kotlin/com/emberjs/utils/utils.kt
+++ b/src/main/kotlin/com/emberjs/utils/utils.kt
@@ -6,10 +6,7 @@ import com.intellij.lang.javascript.psi.JSCallExpression
 import com.intellij.lang.javascript.psi.JSElement
 import com.intellij.lang.javascript.psi.JSFunction
 import com.intellij.lang.javascript.psi.JSReferenceExpression
-import com.intellij.lang.javascript.psi.ecma6.TypeScriptClass
-import com.intellij.lang.javascript.psi.ecma6.TypeScriptInterface
-import com.intellij.lang.javascript.psi.ecma6.TypeScriptObjectType
-import com.intellij.lang.javascript.psi.ecma6.TypeScriptSingleType
+import com.intellij.lang.javascript.psi.ecma6.*
 import com.intellij.lang.javascript.psi.ecmal4.JSClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -34,6 +31,10 @@ fun resolveHelper(file: PsiFile): JSFunction? {
     return null
 }
 
+fun findHelperParams(file: PsiFile) {
+    resolveHelper(file)
+}
+
 
 fun findDefaultExportClass(file: PsiFile): JSClass? {
     val exp = ES6PsiUtil.findDefaultExport(file)
@@ -47,7 +48,7 @@ fun findDefaultExportClass(file: PsiFile): JSClass? {
         cls = PsiTreeUtil.findChildOfType(ref?.resolve(), JSClass::class.java)
         return cls
     }
-    return cls
+    return cls as JSClass
 }
 
 
@@ -59,6 +60,9 @@ fun findComponentArgsType(tsFile: PsiFile): TypeScriptObjectType? {
         val res = (type.children[0] as PsiReference).resolve()
         if (res is TypeScriptInterface) {
             jsObject = res.body
+        }
+        if (res is TypeScriptTypeAlias) {
+            jsObject = res.children.find { it is TypeScriptObjectType } as TypeScriptObjectType
         }
         if (res is TypeScriptObjectType) {
             jsObject = res

--- a/src/main/kotlin/com/emberjs/utils/utils.kt
+++ b/src/main/kotlin/com/emberjs/utils/utils.kt
@@ -1,0 +1,71 @@
+package com.emberjs.utils
+
+import com.intellij.lang.ecmascript6.psi.JSClassExpression
+import com.intellij.lang.ecmascript6.resolve.ES6PsiUtil
+import com.intellij.lang.javascript.psi.JSCallExpression
+import com.intellij.lang.javascript.psi.JSElement
+import com.intellij.lang.javascript.psi.JSFunction
+import com.intellij.lang.javascript.psi.JSReferenceExpression
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptClass
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptInterface
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptObjectType
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptSingleType
+import com.intellij.lang.javascript.psi.ecmal4.JSClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiReference
+import com.intellij.psi.util.PsiTreeUtil
+
+fun resolveHelper(file: PsiFile): JSFunction? {
+    val exp = ES6PsiUtil.findDefaultExport(file)
+    // find class (helpers with class)
+    var cls: JSElement? = PsiTreeUtil.findChildOfType(exp, JSClassExpression::class.java)
+    // find function (for helpers)
+    cls = cls ?: PsiTreeUtil.findChildOfType(exp, JSCallExpression::class.java)
+    if (cls is JSCallExpression && cls.argumentList != null) {
+        var func: PsiElement? = cls.argumentList!!.arguments.last()
+        while (func is JSReferenceExpression) {
+            func = func.resolve()
+        }
+        if (func is JSFunction) {
+            return func
+        }
+    }
+    return null
+}
+
+
+fun findDefaultExportClass(file: PsiFile): JSClass? {
+    val exp = ES6PsiUtil.findDefaultExport(file)
+    var cls: Any? = PsiTreeUtil.findChildOfType(exp, JSClass::class.java)
+    if (cls == null) {
+        val ref = PsiTreeUtil.findChildOfType(exp, JSReferenceExpression::class.java)
+        cls = ref?.resolve()
+        if (cls is JSClass) {
+            return cls
+        }
+        cls = PsiTreeUtil.findChildOfType(ref?.resolve(), JSClass::class.java)
+        return cls
+    }
+    return cls
+}
+
+
+fun findComponentArgsType(tsFile: PsiFile): TypeScriptObjectType? {
+    val cls = findDefaultExportClass(tsFile)
+    val type = PsiTreeUtil.findChildOfType(cls, TypeScriptSingleType::class.java)
+    var jsObject: TypeScriptObjectType? = null
+    if (type?.children?.getOrNull(0) is JSReferenceExpression) {
+        val res = (type.children[0] as PsiReference).resolve()
+        if (res is TypeScriptInterface) {
+            jsObject = res.body
+        }
+        if (res is TypeScriptObjectType) {
+            jsObject = res
+        }
+    }
+    if (type?.children?.getOrNull(0) is TypeScriptObjectType) {
+        jsObject = type.children[0] as TypeScriptObjectType
+    }
+    return jsObject
+}

--- a/src/main/kotlin/com/emberjs/utils/utils.kt
+++ b/src/main/kotlin/com/emberjs/utils/utils.kt
@@ -1,20 +1,24 @@
 package com.emberjs.utils
 
+import com.intellij.lang.ecmascript6.psi.ES6ImportExportDeclaration
 import com.intellij.lang.ecmascript6.psi.JSClassExpression
 import com.intellij.lang.ecmascript6.resolve.ES6PsiUtil
-import com.intellij.lang.javascript.psi.JSCallExpression
-import com.intellij.lang.javascript.psi.JSElement
-import com.intellij.lang.javascript.psi.JSFunction
-import com.intellij.lang.javascript.psi.JSReferenceExpression
+import com.intellij.lang.javascript.psi.*
 import com.intellij.lang.javascript.psi.ecma6.*
 import com.intellij.lang.javascript.psi.ecmal4.JSClass
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiReference
 import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.annotations.NotNull
 
 fun resolveHelper(file: PsiFile): JSFunction? {
-    val exp = ES6PsiUtil.findDefaultExport(file)
+    var exp = ES6PsiUtil.findDefaultExport(file)
+    val exportImport = PsiTreeUtil.findChildOfType(file, ES6ImportExportDeclaration::class.java)
+    if (exportImport != null) {
+        exp = ES6PsiUtil.resolveDefaultExport(exportImport).firstOrNull() as JSElement? ?: exp
+    }
+
     // find class (helpers with class)
     var cls: JSElement? = PsiTreeUtil.findChildOfType(exp, JSClassExpression::class.java)
     // find function (for helpers)
@@ -31,8 +35,8 @@ fun resolveHelper(file: PsiFile): JSFunction? {
     return null
 }
 
-fun findHelperParams(file: PsiFile) {
-    resolveHelper(file)
+fun findHelperParams(file: PsiFile): Array<JSParameterListElement>? {
+    return resolveHelper(file)?.parameters
 }
 
 

--- a/src/main/kotlin/com/emberjs/utils/utils.kt
+++ b/src/main/kotlin/com/emberjs/utils/utils.kt
@@ -52,7 +52,7 @@ fun findDefaultExportClass(file: PsiFile): JSClass? {
     var cls: Any? = exp?.children?.find { it is JSClass }
     cls = cls ?: exp?.children?.find { it is JSFunction }
     if (cls == null) {
-        val ref = exp?.children?.find { it is JSReferenceExpression }
+        val ref: JSReferenceExpression? = exp?.children?.find { it is JSReferenceExpression } as JSReferenceExpression?
         cls = ref?.resolve()
         if (cls is JSClass) {
             return cls

--- a/src/main/resources/META-INF/handlebars.xml
+++ b/src/main/resources/META-INF/handlebars.xml
@@ -2,7 +2,7 @@
 <idea-plugin version="2">
     <extensions defaultExtensionNs="com.intellij">
         <completion.contributor language="Handlebars" implementationClass="com.emberjs.hbs.HbsCompletionContributor"/>
-        <psi.referenceContributor language="Handlebars" implementation="com.emberjs.hbs.HbsReferenceContributor"/>
+        <psi.referenceContributor languages="Handlebars,HTML" implementation="com.emberjs.hbs.HbsReferenceContributor"/>
 
         <lang.foldingBuilder language="Handlebars" implementationClass="com.emberjs.translations.EmberIntlFoldingBuilder"/>
         <lang.foldingBuilder language="Handlebars" implementationClass="com.emberjs.translations.EmberI18nFoldingBuilder"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -50,12 +50,9 @@
         <fileBasedIndex  implementation="com.emberjs.index.EmberNameIndex"/>
         <gotoClassContributor implementation="com.emberjs.navigation.EmberGotoClassContributor"/>
         <gotoRelatedProvider implementation="com.emberjs.navigation.EmberGotoRelatedProvider"/>
-        <lang.documentationProvider language="Handlebars" order="first" implementationClass="com.emberjs.EmberHbsDocumentationProvider"/>
-        <lang.documentationProvider language="ECMAScript 6" order="first" implementationClass="com.emberjs.EmberHbsDocumentationProvider"/>
-        <lang.documentationProvider language="HTML" order="first" implementationClass="com.emberjs.EmberHbsDocumentationProvider"/>
         <codeInsight.parameterInfo language="Handlebars" implementationClass="com.emberjs.hbs.HbsParameterInfoHandler"/>
         <codeInsight.parameterNameHints language="Handlebars" implementationClass="com.emberjs.hbs.HbsParameterNameHints"/>
-        <renamePsiElementProcessor implementation="com.emberjs.psi.RenamePropertyProcessor"/>
+        <renamePsiElementProcessor implementation="com.emberjs.psi.RenameHbsIdProcessor"/>
         <lang.refactoringSupport language="Handlebars" implementationClass="com.emberjs.psi.HbsRefactoringSupportProvider"/>
         <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberInjectionAnnotator"/>
         <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberRelationshipAnnotator"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -55,6 +55,8 @@
         <lang.documentationProvider language="HTML" order="first" implementationClass="com.emberjs.EmberHbsDocumentationProvider"/>
         <codeInsight.parameterInfo language="Handlebars" implementationClass="com.emberjs.hbs.HbsParameterInfoHandler"/>
         <codeInsight.parameterNameHints language="Handlebars" implementationClass="com.emberjs.hbs.HbsParameterNameHints"/>
+        <renamePsiElementProcessor implementation="com.emberjs.psi.RenamePropertyProcessor"/>
+        <lang.refactoringSupport language="Handlebars" implementationClass="com.emberjs.psi.HbsRefactoringSupportProvider"/>
         <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberInjectionAnnotator"/>
         <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberRelationshipAnnotator"/>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -53,6 +53,8 @@
         <lang.documentationProvider language="Handlebars" order="first" implementationClass="com.emberjs.EmberHbsDocumentationProvider"/>
         <lang.documentationProvider language="ECMAScript 6" order="first" implementationClass="com.emberjs.EmberHbsDocumentationProvider"/>
         <lang.documentationProvider language="HTML" order="first" implementationClass="com.emberjs.EmberHbsDocumentationProvider"/>
+        <codeInsight.parameterInfo language="Handlebars" implementationClass="com.emberjs.hbs.HbsParameterInfoHandler"/>
+        <codeInsight.parameterNameHints language="Handlebars" implementationClass="com.emberjs.hbs.HbsParameterNameHints"/>
         <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberInjectionAnnotator"/>
         <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberRelationshipAnnotator"/>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -52,8 +52,6 @@
         <gotoRelatedProvider implementation="com.emberjs.navigation.EmberGotoRelatedProvider"/>
         <codeInsight.parameterInfo language="Handlebars" implementationClass="com.emberjs.hbs.HbsParameterInfoHandler"/>
         <codeInsight.parameterNameHints language="Handlebars" implementationClass="com.emberjs.hbs.HbsParameterNameHints"/>
-        <renamePsiElementProcessor implementation="com.emberjs.psi.RenameHbsIdProcessor"/>
-        <lang.refactoringSupport language="Handlebars" implementationClass="com.emberjs.psi.HbsRefactoringSupportProvider"/>
         <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberInjectionAnnotator"/>
         <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberRelationshipAnnotator"/>
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -47,9 +47,12 @@
         <directoryProjectConfigurator implementation="com.emberjs.cli.EmberCliProjectConfigurator"
                                       order="after PlatformProjectConfigurator"/>
 
-        <fileBasedIndex implementation="com.emberjs.index.EmberNameIndex"/>
+        <fileBasedIndex  implementation="com.emberjs.index.EmberNameIndex"/>
         <gotoClassContributor implementation="com.emberjs.navigation.EmberGotoClassContributor"/>
         <gotoRelatedProvider implementation="com.emberjs.navigation.EmberGotoRelatedProvider"/>
+        <lang.documentationProvider language="Handlebars" order="first" implementationClass="com.emberjs.EmberHbsDocumentationProvider"/>
+        <lang.documentationProvider language="ECMAScript 6" order="first" implementationClass="com.emberjs.EmberHbsDocumentationProvider"/>
+        <lang.documentationProvider language="HTML" order="first" implementationClass="com.emberjs.EmberHbsDocumentationProvider"/>
         <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberInjectionAnnotator"/>
         <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberRelationshipAnnotator"/>
 
@@ -106,7 +109,6 @@
     <extensions defaultExtensionNs="JavaScript">
         <moduleReferenceContributor implementation="com.emberjs.resolver.EmberModuleReferenceContributor"/>
     </extensions>
-
     <actions>
         <action id="GenerateEmberCode" class="com.emberjs.actions.EmberGenerateCodeAction">
             <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFromTemplate"/>

--- a/src/test/kotlin/com/emberjs/EmberTestFixtures.kt
+++ b/src/test/kotlin/com/emberjs/EmberTestFixtures.kt
@@ -27,6 +27,6 @@ object EmberTestFixtures {
             }
         }
 
-        else -> MockVirtualFile(file.name)
+        else -> MockVirtualFile(file.name, file.readText())
     }
 }

--- a/src/test/kotlin/com/emberjs/hbs/HbsCompletionTest.kt
+++ b/src/test/kotlin/com/emberjs/hbs/HbsCompletionTest.kt
@@ -1,0 +1,206 @@
+package com.emberjs.hbs
+
+import com.dmarcotte.handlebars.file.HbFileType
+import com.dmarcotte.handlebars.parsing.HbTokenTypes
+import com.dmarcotte.handlebars.psi.impl.HbPathImpl
+import com.intellij.codeInsight.completion.CompletionType
+import com.intellij.lang.ecmascript6.psi.JSClassExpression
+import com.intellij.lang.javascript.psi.JSField
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptPropertySignature
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parentsWithSelf
+import com.intellij.refactoring.suggested.endOffset
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.jetbrains.rd.util.assert
+import kotlin.test.assert
+
+class HbsCompletionTest : BasePlatformTestCase() {
+    fun testLocalFromMustach() {
+        val hbs = """
+            {{#each this.items as |item index|}}
+                {{i}}
+                {{it}}
+                {{th}}
+                {{ind}}
+                {{in-helper (fn it)}}
+            {{/each}}
+        """.trimIndent()
+        myFixture.configureByText(HbFileType.INSTANCE, hbs)
+        val element = PsiTreeUtil.collectElements(myFixture.file, { it.elementType == HbTokenTypes.ID })
+        val resolvedItem = element.find { it.text == "i" }
+        val resolvedItemA = element.find { it.text == "it" }
+        val resolvedItemThis = element.find { it.text == "th" }
+        val resolvedIndex = element.find { it.text == "ind" }
+        val resolvedItemInFn = element.find { it.text == "it" }
+        assert(resolvedItem != null)
+
+        myFixture.editor.caretModel.moveToOffset(resolvedItem!!.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        var completions = myFixture.lookupElementStrings!!
+        assert(completions.containsAll(listOf("if", "in-element", "input", "item", "index", "action", "link-to", "yield")))
+
+        myFixture.editor.caretModel.moveToOffset(resolvedItemA!!.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        assert(myFixture.lookupElementStrings == null && resolvedItemA.text == "item")
+
+        myFixture.editor.caretModel.moveToOffset(resolvedItemThis!!.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        assert(myFixture.lookupElementStrings == null && resolvedItemThis.text == "this")
+
+        myFixture.editor.caretModel.moveToOffset(resolvedIndex!!.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        assert(myFixture.lookupElementStrings == null && resolvedIndex.text == "index")
+
+        myFixture.editor.caretModel.moveToOffset(resolvedItemInFn!!.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        assert(myFixture.lookupElementStrings == null && resolvedItemInFn.text == "item")
+    }
+
+    fun testLocalFromAnglebracket() {
+        val hbs = """
+            <MyComponent as |item index|}}
+                {{i}}
+                {{it}}
+                {{th}}
+                {{ind}}
+                {{in-helper (fn it)}}
+            </MyComponent>
+        """.trimIndent()
+        myFixture.configureByText(HbFileType.INSTANCE, hbs)
+        val element = PsiTreeUtil.collectElements(myFixture.file, { it.elementType == HbTokenTypes.ID })
+        val resolvedItem = element.find { it.text == "i" }
+        val resolvedItemA = element.find { it.text == "it" }
+        val resolvedItemThis = element.find { it.text == "th" }
+        val resolvedIndex = element.find { it.text == "ind" }
+        val resolvedItemInFn = element.find { it.text == "it" }
+        assert(resolvedItem != null)
+
+            myFixture.editor.caretModel.moveToOffset(resolvedItem!!.endOffset)
+            myFixture.complete(CompletionType.BASIC)
+            var completions = myFixture.lookupElementStrings!!
+            assert(completions.containsAll(listOf("item", "index")))
+
+            myFixture.editor.caretModel.moveToOffset(resolvedItemA!!.endOffset)
+            myFixture.complete(CompletionType.BASIC)
+            assert(myFixture.lookupElementStrings == null && resolvedItemA.text == "item")
+
+            myFixture.editor.caretModel.moveToOffset(resolvedItemThis!!.endOffset)
+            myFixture.complete(CompletionType.BASIC)
+            assert(myFixture.lookupElementStrings == null && resolvedItemThis.text == "this")
+
+            myFixture.editor.caretModel.moveToOffset(resolvedIndex!!.endOffset)
+            myFixture.complete(CompletionType.BASIC)
+            assert(myFixture.lookupElementStrings == null && resolvedIndex.text == "index")
+
+            myFixture.editor.caretModel.moveToOffset(resolvedItemInFn!!.endOffset)
+            myFixture.complete(CompletionType.BASIC)
+            assert(myFixture.lookupElementStrings == null && resolvedItemInFn.text == "item")
+    }
+
+    fun testToTsFile() {
+        val hbs = """
+            {{this.}}
+            {{this.x.}}
+            {{this.y.}}
+            {{x}}
+            {{in-helper (fn this.)}}
+        """.trimIndent()
+        val ts = """
+            export default class extends Component {
+                @tracked a;
+                x: { b: string };
+                /**
+                 * @type {{b: string}}
+                 */
+                y;
+            }
+        """.trimIndent()
+        myFixture.addFileToProject("component.ts", ts)
+        myFixture.configureByText("template.hbs", hbs)
+        val element = PsiTreeUtil.collectElements(myFixture.file, { it.elementType == HbTokenTypes.ID })
+        val resolvedA = element.find { it.parent.text == "this." }!!.nextSibling.nextSibling
+        val resolvedXB = element.find { it.parent.text == "this.x" }!!.parent.parent.nextSibling
+        val resolvedYB = element.find { it.parent.text == "this.y" }!!.parent.parent.nextSibling
+        val notResolvedX = element.find { it.parentsWithSelf.find { it is HbPathImpl }?.text == "x" }!!
+        val resolvedXInHelper = element.findLast { it.parent.text == "this." }!!.nextSibling.nextSibling
+
+        myFixture.editor.caretModel.moveToOffset(resolvedA.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        var completions = myFixture.lookupElementStrings!!
+        assert(completions.containsAll(listOf("x", "y", "a")))
+
+        myFixture.editor.caretModel.moveToOffset(resolvedXB.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        completions = myFixture.lookupElementStrings!!
+        assert(completions.containsAll(listOf("b")))
+
+        myFixture.editor.caretModel.moveToOffset(resolvedYB.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        completions = myFixture.lookupElementStrings!!
+        assert(completions.containsAll(listOf("b")))
+
+        myFixture.editor.caretModel.moveToOffset(notResolvedX.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        completions = myFixture.lookupElementStrings!!
+        assert(completions.containsAll(listOf("textarea")))
+
+        myFixture.editor.caretModel.moveToOffset(resolvedXInHelper.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        completions = myFixture.lookupElementStrings!!
+        assert(completions.containsAll(listOf("a", "x", "y")))
+    }
+
+    fun testToJsFile() {
+        val hbs = """
+            {{this.}}
+            {{this.x.}}
+            {{this.y.}}
+            {{x}}
+            {{in-helper (fn this.)}}
+        """.trimIndent()
+        val js = """
+            export default class extends Component {
+                @tracked a;
+                x: { b: string };
+                /**
+                 * @type {{b: string}}
+                 */
+                y;
+            }
+        """.trimIndent()
+        myFixture.addFileToProject("component.js", js)
+        myFixture.configureByText("template.hbs", hbs)
+        val element = PsiTreeUtil.collectElements(myFixture.file, { it.elementType == HbTokenTypes.ID })
+        val resolvedA = element.find { it.parent.text == "this." }!!.nextSibling.nextSibling
+        val resolvedXB = element.find { it.parent.text == "this.x" }!!.parent.parent.nextSibling
+        val resolvedYB = element.find { it.parent.text == "this.y" }!!.parent.parent.nextSibling
+        val notResolvedX = element.find { it.parentsWithSelf.find { it is HbPathImpl }?.text == "x" }!!
+        val resolvedXInHelper = element.findLast { it.parent.text == "this." }!!.nextSibling.nextSibling
+
+        myFixture.editor.caretModel.moveToOffset(resolvedA.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        var completions = myFixture.lookupElementStrings!!
+        assert(completions.containsAll(listOf("x", "y", "a")))
+
+        myFixture.editor.caretModel.moveToOffset(resolvedXB.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        completions = myFixture.lookupElementStrings!!
+        assert(completions.containsAll(listOf("b")))
+
+        myFixture.editor.caretModel.moveToOffset(resolvedYB.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        completions = myFixture.lookupElementStrings!!
+        assert(completions.containsAll(listOf("b")))
+
+        myFixture.editor.caretModel.moveToOffset(notResolvedX.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        completions = myFixture.lookupElementStrings!!
+        assert(completions.containsAll(listOf("textarea")))
+
+        myFixture.editor.caretModel.moveToOffset(resolvedXInHelper.endOffset)
+        myFixture.complete(CompletionType.BASIC)
+        completions = myFixture.lookupElementStrings!!
+        assert(completions.containsAll(listOf("a", "x", "y")))
+    }
+}

--- a/src/test/kotlin/com/emberjs/hbs/HbsReferencesTest.kt
+++ b/src/test/kotlin/com/emberjs/hbs/HbsReferencesTest.kt
@@ -1,0 +1,238 @@
+package com.emberjs.hbs
+
+import com.dmarcotte.handlebars.file.HbFileType
+import com.dmarcotte.handlebars.parsing.HbTokenTypes
+import com.dmarcotte.handlebars.psi.impl.HbPathImpl
+import com.intellij.lang.ecmascript6.psi.JSClassExpression
+import com.intellij.lang.javascript.psi.JSField
+import com.intellij.lang.javascript.psi.ecma6.TypeScriptPropertySignature
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.elementType
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.jetbrains.rd.util.assert
+import kotlin.test.assert
+
+class HbsReferencesTest : BasePlatformTestCase() {
+    fun testLocalFromMustach() {
+        val hbs = """
+            {{#each this.items as |item index|}}
+                {{item}}
+                {{item.a}}
+                {{index}}
+                {{in-helper (fn item)}}
+            {{/each}}
+        """.trimIndent()
+        myFixture.configureByText(HbFileType.INSTANCE, hbs)
+        val element = PsiTreeUtil.collectElements(myFixture.file, { it is HbPathImpl })
+        val resolvedItem = element.find { it.text == "item" }?.children?.get(0)?.references?.find { it is HbsLocalReference }?.resolve()
+        val resolvedItemA = element.find { it.text == "item.a" }?.children?.get(0)?.references?.find { it is HbsLocalReference }?.resolve()
+        val resolvedIndex = element.find { it.text == "index" }?.children?.get(0)?.references?.find { it is HbsLocalReference }?.resolve()
+        val resolvedItemInFn = element.find { it.text == "item" }?.children?.get(0)?.references?.find { it is HbsLocalReference }?.resolve()
+        assert(resolvedItem != null)
+        assert(resolvedItemA != null)
+        assert(resolvedIndex != null)
+        assert(resolvedItemInFn != null)
+    }
+
+    fun testLocalFromAnglebarcket() {
+        val hbs = """
+            <MyComponent as |item index|}}
+                {{item}}
+                {{item.a}}
+                {{index}}
+                {{in-helper (fn item)}}
+            </MyComponent>
+        """.trimIndent()
+        myFixture.configureByText(HbFileType.INSTANCE, hbs)
+        val element = PsiTreeUtil.collectElements(myFixture.file, { it is HbPathImpl })
+        val resolvedItem = element.find { it.text == "item" }?.children?.get(0)?.references?.find { it is HbsLocalReference }?.resolve()
+        val resolvedItemA = element.find { it.text == "item.a" }?.children?.get(0)?.references?.find { it is HbsLocalReference }?.resolve()
+        val resolvedIndex = element.find { it.text == "index" }?.children?.get(0)?.references?.find { it is HbsLocalReference }?.resolve()
+        val resolvedItemInFn = element.find { it.text == "item" }?.children?.get(0)?.references?.find { it is HbsLocalReference }?.resolve()
+        assert(resolvedItem != null)
+        assert(resolvedItemA != null)
+        assert(resolvedIndex != null)
+        assert(resolvedItemInFn != null)
+    }
+
+    fun testToTsFile() {
+        val hbs = """
+            {{this.a}}
+            {{this.x.b}}
+            {{this.y.b}}
+            {{x}}
+            {{in-helper (fn this.x)}}
+        """.trimIndent()
+        val ts = """
+            export default class extends Component {
+                @tracked a;
+                x: { b: string };
+                /**
+                 * @type {{b: string}}
+                 */
+                y;
+            }
+        """.trimIndent()
+        myFixture.addFileToProject("component.ts", ts)
+        myFixture.configureByText("template.hbs", hbs)
+        val element = PsiTreeUtil.collectElements(myFixture.file, { it.elementType == HbTokenTypes.ID })
+        val resolvedA = element.find { it.parent.text == "this.a" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        val resolvedXB = element.find { it.parent.text == "this.x.b" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        val resolvedYB = element.find { it.parent.text == "this.y.b" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        val notResolvedX = element.find { it.parent.text == "x" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        val resolvedXInHelper = element.findLast { it.parent.text == "this.x" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        assert(resolvedA.first() is JSClassExpression && resolvedA[1] is JSField)
+        assert(resolvedXB[0] is JSClassExpression && resolvedXB[1] is JSField && resolvedXB[2] is TypeScriptPropertySignature)
+        assert(resolvedYB.first() is JSClassExpression && resolvedA[1] is JSField /*&& need to resolve doc*/)
+        assert(resolvedXInHelper.first() is JSClassExpression && resolvedA[1] is JSField)
+        assert(notResolvedX.isEmpty())
+    }
+
+    fun testToJsFile() {
+        val hbs = """
+            {{this.a}}
+            {{this.x.b}}
+            {{this.y.b}}
+            {{x}}
+            {{in-helper (fn this.x)}}
+        """.trimIndent()
+        val js = """
+            export default class extends Component {
+                @tracked a;
+                /**
+                 * @type {{b: string}}
+                 */
+                x: { b: string };
+                /**
+                 * @type {{b: string}}
+                 */
+                y;
+            }
+        """.trimIndent()
+        myFixture.addFileToProject("component.js", js)
+        myFixture.configureByText("template.hbs", hbs)
+        val element = PsiTreeUtil.collectElements(myFixture.file, { it.elementType == HbTokenTypes.ID })
+        val resolvedA = element.find { it.parent.text == "this.a" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        val resolvedXB = element.find { it.parent.text == "this.x.b" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        val resolvedYB = element.find { it.parent.text == "this.y.b" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        val notResolvedX = element.find { it.parent.text == "x" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        val resolvedXInHelper = element.findLast { it.parent.text == "this.x" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        assert(resolvedA.first() is JSClassExpression && resolvedA[1] is JSField)
+        assert(resolvedXB[0] is JSClassExpression && resolvedXB[1] is JSField /*&& resolvedXB[2] is TypeScriptPropertySignature*/)
+        assert(resolvedYB.first() is JSClassExpression && resolvedA[1] is JSField /*&& need to resolve doc*/)
+        assert(resolvedXInHelper.first() is JSClassExpression && resolvedA[1] is JSField)
+        assert(notResolvedX.isEmpty())
+    }
+
+    fun testLetHelper() {
+        val hbs = """
+            {{#let this as |self|}}
+                {{self.a}}
+                {{self.x.b}}
+                {{self.y.b}}
+                {{x}}
+                {{in-helper (fn self.x)}}
+            {{/let}} 
+        """.trimIndent()
+        val js = """
+            export default class extends Component {
+                @tracked a;
+                /**
+                 * @type {{b: string}}
+                 */
+                x: { b: string };
+                /**
+                 * @type {{b: string}}
+                 */
+                y;
+            }
+        """.trimIndent()
+        myFixture.addFileToProject("component.js", js)
+        myFixture.configureByText("template.hbs", hbs)
+        val element = PsiTreeUtil.collectElements(myFixture.file, { it.elementType == HbTokenTypes.ID })
+        val resolvedBlock = element.find { it.parent.text == "self" }!!.parent.references.first()
+        val resolvedA = element.find { it.parent.text == "self.a" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        val resolvedXB = element.find { it.parent.text == "self.x.b" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        val resolvedYB = element.find { it.parent.text == "self.y.b" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        val notResolvedX = element.find { it.parent.text == "x" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+        val resolvedXInHelper = element.findLast { it.parent.text == "self.x" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+
+        assert(resolvedBlock is HbsLocalReference)
+        val param = PsiTreeUtil.findSiblingBackward(element.find { it.parent.text == "self" }!!.parent, HbTokenTypes.PARAM, null)
+        val ref = PsiTreeUtil.collectElements(param, { it.elementType == HbTokenTypes.ID }).last()
+        assert(resolvedBlock.resolve() == ref.parent)
+        assert(resolvedA.first() is PsiElement && resolvedA[1] is JSField)
+        assert(resolvedXB[0] is PsiElement && resolvedXB[1] is JSField /*&& resolvedXB[2] is TypeScriptPropertySignature*/)
+        assert(resolvedYB.first() is PsiElement && resolvedA[1] is JSField /*&& need to resolve doc*/)
+        assert(resolvedXInHelper.first() is PsiElement && resolvedA[1] is JSField)
+        assert(notResolvedX.isEmpty())
+    }
+
+    fun testLetHelper2() {
+        val hbs = """
+            {{#let this.x as |self|}}
+                {{self.b}}
+            {{/let}} 
+        """.trimIndent()
+        val js = """
+            export default class extends Component {
+                @tracked a;
+                /**
+                 * @type {{b: string}}
+                 */
+                x: { b: string };
+                /**
+                 * @type {{b: string}}
+                 */
+                y;
+            }
+        """.trimIndent()
+        myFixture.addFileToProject("component.js", js)
+        myFixture.configureByText("template.hbs", hbs)
+        val element = PsiTreeUtil.collectElements(myFixture.file, { it.elementType == HbTokenTypes.ID })
+        val resolvedBlock = element.find { it.parent.text == "self" }!!.parent.references.first()
+        val resolvedA = element.find { it.parent.text == "self.b" }!!.parent.children.map { it.references }
+                .filter { it.isNotEmpty() }.map { it.first().resolve() }
+
+        assert(resolvedBlock is HbsLocalReference)
+        val param = PsiTreeUtil.findSiblingBackward(element.find { it.parent.text == "self" }!!.parent, HbTokenTypes.PARAM, null)
+        val ref = PsiTreeUtil.collectElements(param, { it.elementType == HbTokenTypes.ID }).last()
+        assert(resolvedBlock.resolve() == ref.parent)
+        assert(resolvedA.first() is PsiElement && resolvedA[1] is TypeScriptPropertySignature)
+    }
+
+        fun testEachHelper() {
+                val hbs = """
+            {{#each this.items as |item|}}
+                {{item.a}}
+            {{/each}} 
+        """.trimIndent()
+                val ts = """
+            export default class extends Component {
+                items: {a: string}[];
+            }
+        """.trimIndent()
+                myFixture.addFileToProject("component.ts", ts)
+                myFixture.configureByText("template.hbs", hbs)
+                val element = PsiTreeUtil.collectElements(myFixture.file, { it.elementType == HbTokenTypes.ID })
+                val resolvedA = element.find { it.parent.text == "item.a" }!!.parent.children.map { it.references }
+                        .filter { it.isNotEmpty() }.map { it.first().resolve() }
+                assert(resolvedA.first() is PsiElement && resolvedA[1] is JSField)
+        }
+}

--- a/src/test/kotlin/com/emberjs/resolver/EmberNameTest.kt
+++ b/src/test/kotlin/com/emberjs/resolver/EmberNameTest.kt
@@ -4,6 +4,7 @@ import com.emberjs.EmberTestFixtures.APTIBLE
 import com.emberjs.EmberTestFixtures.CRATES_IO
 import com.emberjs.EmberTestFixtures.EXAMPLE
 import com.emberjs.utils.find
+import com.emberjs.utils.parentEmberModule
 import com.emberjs.utils.use
 import com.intellij.openapi.vfs.VirtualFile
 import org.assertj.core.api.Assertions.assertThat
@@ -110,7 +111,8 @@ class EmberNameTest {
             "app/styles/some-route.css" to "styles:some-route",
             "app/styles/components/some-component.css" to "styles:components/some-component",
             "app/components/test-component-nested/index.js" to "component:test-component-nested/index",
-            "app/components/test-component-nested/index.hbs" to "template:components/test-component-nested/index"
+            "app/components/test-component-nested/index.hbs" to "template:components/test-component-nested/index",
+            "node_modules/my-components/addon/components/button/component.js" to "component:button"
     ))
 
     @Test fun testAptible() = doTest(APTIBLE, mapOf(
@@ -138,7 +140,7 @@ class EmberNameTest {
     private fun doTest(root: VirtualFile, tests: Map<String, String?>) {
         SoftAssertions().use {
             for ((path, expectedName) in tests) {
-                assertThat(EmberName.from(root, root.find(path))?.fullName)
+                assertThat(EmberName.from(root.find(path).parentEmberModule!!, root.find(path))?.fullName)
                         .describedAs(path)
                         .apply { if (expectedName == null) isNull() else isEqualTo(expectedName) }
 

--- a/src/test/resources/com/emberjs/fixtures/example/.gitignore
+++ b/src/test/resources/com/emberjs/fixtures/example/.gitignore
@@ -5,7 +5,6 @@
 /tmp
 
 # dependencies
-/node_modules
 /bower_components
 
 # misc

--- a/src/test/resources/com/emberjs/fixtures/example/node_modules/my-components/package.json
+++ b/src/test/resources/com/emberjs/fixtures/example/node_modules/my-components/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "my-components",
+  "version": "0.0.0",
+  "description": "Small description for example goes here",
+  "private": true,
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
+  "scripts": {
+    "build": "ember build",
+    "start": "ember server",
+    "test": "ember test"
+  },
+  "repository": "",
+  "engines": {
+    "node": ">= 0.10.0"
+  },
+  "author": "",
+  "license": "MIT",
+  "ember-addon": {
+    "main": "addon"
+  },
+  "devDependencies": {
+  }
+}

--- a/src/test/resources/com/emberjs/fixtures/example/node_modules/my-components/package.json
+++ b/src/test/resources/com/emberjs/fixtures/example/node_modules/my-components/package.json
@@ -21,6 +21,7 @@
   "ember-addon": {
     "main": "addon"
   },
+  "keywords": ["ember-addon"],
   "devDependencies": {
   }
 }

--- a/src/test/resources/com/emberjs/fixtures/example/package.json
+++ b/src/test/resources/com/emberjs/fixtures/example/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
+    "my-components": "1.0",
     "ember-cli": "1.13.12",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.5",


### PR DESCRIPTION
warning: big PR :)

- [x] include ember addons for component lookup by checking package.json keywords. Fixes https://github.com/Turbo87/intellij-emberjs/issues/184
- [x] include modifiers
- [x] add import path to autocomplete description
- [x] add reference and autocomplete for attributes to `@xxx` in template or resolve from Component<Args> (ts or d.ts). Also fixes https://github.com/Turbo87/intellij-emberjs/issues/243 and https://github.com/Turbo87/intellij-emberjs/issues/204
- [x] add reference and autocomplete from local param blocks `|param1 param2|`
- [x] add reference to yields and dereference for autocomplete tags and mustache
- [x] add references to template component or controller.(js/ts) (this.x)
- [x] add autocomplete for helpers with hash
- [x] add param hints for helpers params, will look like: `(helper x:param1 y: param2)` or `(helper [0]:param0 [1]:param1)`
- [x] add parameter info for helpers
- [ ] add parameter lookup (ctrl+p) for helpers and modifiers
- [ ] rename all instances of an ID
- [ ] rename instances of ID that reference an tag block param
- [x] added tests
- [ ] add parameter info for components in hash form
- [ ] add parameter info for internal helpers and components
- [ ] add attributes autcomplete for internal components
- [x] provide documentation for emberjs internal helpers
- [ ] provide documentation for emberjs internal Components
- [x] enjoy :)

i added a file to reference the internal template helpers, but do not know how to reference them...
like JS does for the internal parts