### PR TITLE
Add param info

### DIFF
--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
@@ -1,0 +1,119 @@
+package com.emberjs.hbs
+
+import com.dmarcotte.handlebars.psi.HbParam
+import com.emberjs.utils.findFirstHbsParamFromParam
+import com.emberjs.utils.followReferences
+import com.emberjs.utils.resolveHelper
+import com.emberjs.utils.resolveModifier
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.lang.javascript.psi.*
+import com.intellij.lang.javascript.psi.types.JSArrayType
+import com.intellij.lang.javascript.psi.types.JSTupleType
+import com.intellij.lang.parameterInfo.*
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+
+
+class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, Any?> {
+    override fun couldShowInLookup(): Boolean {
+        return true
+    }
+
+    override fun getParametersForLookup(item: LookupElement?, context: ParameterInfoContext?): Array<*>? {
+        val psiElement = context?.file?.findElementAt(context.offset)
+        val helper = findFirstHbsParamFromParam(psiElement)
+
+        val file = helper?.references?.getOrNull(0)?.resolve()?.containingFile
+        if (file == null) {
+            return null
+        }
+        return resolveHelper(file)?.parameters
+    }
+
+    override fun findElementForParameterInfo(context: CreateParameterInfoContext): PsiElement? {
+        val psiElement = context.file.findElementAt(context.offset)
+        val block = findFirstHbsParamFromParam(psiElement)
+        val ref = followReferences(block)
+        if (ref == null) {
+            return null
+        }
+        val func = resolveHelper(ref.containingFile)
+        if (func == null) {
+            val modifier = resolveModifier(ref.containingFile)
+            if (modifier.filterNotNull().isNotEmpty()) {
+                val args = emptyList<Any>().toMutableList()
+                val argType = modifier.first()?.parameters?.getOrNull(2)?.jsType
+                        ?: modifier[1]?.parameters?.getOrNull(1)?.jsType
+                        ?: modifier[2]?.parameters?.getOrNull(1)?.jsType
+                if (argType is JSRecordType) {
+                    val positional = argType.findPropertySignature("positional")
+                    if (positional != null) {
+                        args.add(positional)
+                    }
+                    val named = argType.findPropertySignature("named")
+                    if (named != null) {
+                        args.add(named)
+                    }
+                }
+                context.itemsToShow = args.toTypedArray()
+            }
+        } else {
+            context.itemsToShow = func.parameters
+        }
+        return psiElement
+    }
+
+    override fun showParameterInfo(element: PsiElement, context: CreateParameterInfoContext) {
+        context.showHint(element, element.textOffset, this)
+    }
+
+    override fun findElementForUpdatingParameterInfo(context: UpdateParameterInfoContext): PsiElement? {
+        return context.file.findElementAt(context.offset)
+    }
+
+    override fun updateParameterInfo(parameterOwner: PsiElement, context: UpdateParameterInfoContext) {
+        val psiElement = context.file.findElementAt(context.offset)
+        if (psiElement == null) {
+            return
+        }
+        val currentParam = psiElement.parent.children.filter { it is HbParam }.indexOf(psiElement) - 1
+        context.setCurrentParameter(currentParam)
+    }
+
+    override fun updateUI(p: Any?, context: ParameterInfoUIContext) {
+        var text = ""
+        if (p == null) {
+            return
+        }
+        var type: JSType? = null
+        var arrayName: String? = null
+        if (p is JSParameterListElement) {
+            arrayName = p.name
+            type = p.inferredType
+        }
+        if (p is JSRecordType.PropertySignature) {
+            arrayName = p.memberName
+            type = p.jsType
+        }
+        if (type is JSArrayType || type is JSTupleType) {
+            if (type is JSTupleType) {
+                val names = type.sourceElement?.children?.map { it.text } ?: emptyList<String>()
+                text += names.mapIndexed { index, s -> "$s:${type.getTypeByIndex(index) ?: "unknown"}" }.joinToString(",")
+            } else {
+                val arrayType = type as JSArrayType
+                text += arrayName + ":" + (arrayType.type?.resolvedTypeText ?: "*")
+            }
+        }
+
+        if (type is JSRecordType) {
+            text += type.properties.map { it.memberName + ":" + it.jsType?.resolvedTypeText + "=" }.joinToString(",")
+        }
+
+
+        if (text == "") {
+            return
+        }
+        context.setupUIComponentPresentation(text, 0, 0, false, false, false, context.defaultParameterColor)
+    }
+
+}

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterInfoHandler.kt
@@ -1,10 +1,8 @@
 package com.emberjs.hbs
 
+import com.dmarcotte.handlebars.parsing.HbTokenTypes
 import com.dmarcotte.handlebars.psi.HbParam
-import com.emberjs.utils.findFirstHbsParamFromParam
-import com.emberjs.utils.followReferences
-import com.emberjs.utils.resolveHelper
-import com.emberjs.utils.resolveModifier
+import com.emberjs.utils.*
 import com.intellij.codeInsight.lookup.LookupElement
 import com.intellij.lang.javascript.psi.*
 import com.intellij.lang.javascript.psi.types.JSArrayType
@@ -12,6 +10,8 @@ import com.intellij.lang.javascript.psi.types.JSTupleType
 import com.intellij.lang.parameterInfo.*
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parents
 
 
 class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, Any?> {
@@ -39,12 +39,10 @@ class HbsParameterInfoHandler : ParameterInfoHandler<PsiElement, Any?> {
         }
         val func = resolveHelper(ref.containingFile)
         if (func == null) {
-            val modifier = resolveModifier(ref.containingFile)
-            if (modifier.filterNotNull().isNotEmpty()) {
+            val modifier = resolveDefaultModifier(ref.containingFile)
+            if (modifier != null) {
                 val args = emptyList<Any>().toMutableList()
-                val argType = modifier.first()?.parameters?.getOrNull(2)?.jsType
-                        ?: modifier[1]?.parameters?.getOrNull(1)?.jsType
-                        ?: modifier[2]?.parameters?.getOrNull(1)?.jsType
+                val argType = modifier.parameters.last().jsType
                 if (argType is JSRecordType) {
                     val positional = argType.findPropertySignature("positional")
                     if (positional != null) {

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
@@ -1,0 +1,99 @@
+package com.emberjs.hbs
+
+import com.dmarcotte.handlebars.psi.HbMustacheName
+import com.dmarcotte.handlebars.psi.HbParam
+import com.emberjs.utils.findFirstHbsParamFromParam
+import com.emberjs.utils.followReferences
+import com.emberjs.utils.resolveHelper
+import com.emberjs.utils.resolveModifier
+import com.intellij.codeInsight.hints.HintInfo
+import com.intellij.codeInsight.hints.InlayInfo
+import com.intellij.codeInsight.hints.InlayParameterHintsProvider
+import com.intellij.codeInsight.hints.Option
+import com.intellij.lang.javascript.psi.*
+import com.intellij.lang.javascript.psi.types.JSTupleType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.refactoring.suggested.startOffset
+import java.lang.Integer.max
+import java.util.*
+
+
+class HbsParameterNameHints : InlayParameterHintsProvider  {
+
+    override fun getParameterHints(psiElement: PsiElement): MutableList<InlayInfo> {
+        if (psiElement is HbParam) {
+            val firstParam = findFirstHbsParamFromParam(psiElement)
+            if (firstParam == null) {
+                return emptyList<InlayInfo>().toMutableList()
+            }
+            var index = max(
+                    firstParam.parent.children.filter { it is HbParam }.indexOf(psiElement),
+                    firstParam.parent.parent.children.filter { it is HbParam }.indexOf(psiElement)
+            )
+            if (index <= 0 && firstParam !is HbMustacheName) {
+                // if its the helper itself
+                return emptyList<InlayInfo>().toMutableList()
+            } else {
+                index += 1
+            }
+
+
+            var file = followReferences(firstParam)
+            if (file == firstParam) {
+                file = followReferences(firstParam)
+            }
+
+            if (file != null) {
+                var func = if (file is PsiFile) resolveHelper(file) else if (file is JSFunction) file else null
+        var arrayName: String? = null
+        var array: JSType? =  null
+
+        if (func != null) {
+            arrayName = func.parameters.first().name ?: arrayName
+            array = func.parameters.first().jsType
+        } else {
+            val modifier = resolveModifier(file.containingFile)
+            val args = modifier.first()?.parameters?.getOrNull(2)?.jsType
+                    ?: modifier[1]?.parameters?.getOrNull(1)?.jsType
+                    ?: modifier[2]?.parameters?.getOrNull(1)?.jsType
+            array = null
+            if (args is JSRecordType) {
+                array = args.findPropertySignature("positional")?.jsType
+                arrayName = "positional"
+            }
+        }
+
+        val type = array
+        if (type is JSTupleType && type.sourceElement != null) {
+            val name = type.sourceElement!!.children.map { it.text }.getOrNull(index-1)
+            if (name != null) {
+                        return mutableListOf(InlayInfo(name, psiElement.startOffset))
+            } else {
+                if (index == 1 && arrayName != null) {
+                    return mutableListOf(InlayInfo(arrayName, psiElement.startOffset))
+                }
+            }
+
+            }
+            }
+        }
+        return emptyList<InlayInfo>().toMutableList()
+    }
+
+    override fun getHintInfo(element: PsiElement): HintInfo? {
+        return null
+    }
+
+    override fun getDefaultBlackList(): MutableSet<String> {
+        return Collections.emptySet()
+    }
+
+    override fun getSupportedOptions(): List<Option?> {
+        return Collections.emptyList()
+    }
+
+    override fun isBlackListSupported(): Boolean {
+        return false
+    }
+}

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
@@ -1,31 +1,25 @@
 package com.emberjs.hbs
 
 import com.dmarcotte.handlebars.parsing.HbTokenTypes
-import com.dmarcotte.handlebars.psi.HbMustacheName
 import com.dmarcotte.handlebars.psi.HbParam
-import com.emberjs.utils.findFirstHbsParamFromParam
-import com.emberjs.utils.followReferences
-import com.emberjs.utils.resolveHelper
-import com.emberjs.utils.resolveModifier
+import com.emberjs.utils.*
 import com.intellij.codeInsight.hints.HintInfo
 import com.intellij.codeInsight.hints.InlayInfo
 import com.intellij.codeInsight.hints.InlayParameterHintsProvider
 import com.intellij.codeInsight.hints.Option
-import com.intellij.lang.javascript.psi.*
+import com.intellij.lang.javascript.psi.JSRecordType
+import com.intellij.lang.javascript.psi.JSType
 import com.intellij.lang.javascript.psi.types.JSTupleType
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiFile
 import com.intellij.psi.impl.source.tree.LeafPsiElement
 import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.psi.util.elementType
-import com.intellij.psi.util.parents
-import com.intellij.refactoring.suggested.endOffset
 import com.intellij.refactoring.suggested.startOffset
 import java.lang.Integer.max
 import java.util.*
 
 
-class HbsParameterNameHints : InlayParameterHintsProvider {
+class HbsParameterNameHints : InlayParameterHintsProvider  {
 
     override fun getParameterHints(psiElement: PsiElement): MutableList<InlayInfo> {
         if (psiElement is HbParam) {
@@ -45,47 +39,46 @@ class HbsParameterNameHints : InlayParameterHintsProvider {
                 return emptyList<InlayInfo>().toMutableList()
             }
 
+
             var file = followReferences(firstParam)
             if (file == firstParam) {
                 file = followReferences(firstParam.children[0])
                 if (file == firstParam.children[0]) {
                     val id = PsiTreeUtil.collectElements(firstParam) { it !is LeafPsiElement && it.elementType == HbTokenTypes.ID }.lastOrNull()
-                    file = followReferences(id)
+                    file = followReferences(id, psiElement.text)
                 }
             }
 
             if (file != null) {
                 var func = resolveHelper(file.containingFile)
-                var arrayName: String? = null
-                var array: JSType? = null
+        var arrayName: String? = null
+        var array: JSType? =  null
 
-                if (func != null) {
-                    arrayName = func.parameters.first().name ?: arrayName
-                    array = func.parameters.first().jsType
-                } else {
-                    val modifier = resolveModifier(file.containingFile)
-                    val args = modifier.first()?.parameters?.getOrNull(2)?.jsType
-                            ?: modifier[1]?.parameters?.getOrNull(1)?.jsType
-                            ?: modifier[2]?.parameters?.getOrNull(1)?.jsType
-                    array = null
-                    if (args is JSRecordType) {
-                        array = args.findPropertySignature("positional")?.jsType
-                        arrayName = "positional"
-                    }
-                }
+        if (func != null) {
+            arrayName = func.parameters.first().name ?: arrayName
+            array = func.parameters.first().jsType
+        } else {
+                    val modifier = resolveDefaultModifier(file.containingFile)
+                    val args = modifier?.parameters?.lastOrNull()?.jsType
+            array = null
+            if (args is JSRecordType) {
+                array = args.findPropertySignature("positional")?.jsType
+                arrayName = "positional"
+            }
+        }
 
-                val type = array
-                if (type is JSTupleType && type.sourceElement != null) {
-                    val name = type.sourceElement!!.children.map { it.text }.getOrNull(index - 1)
-                    if (name != null) {
+        val type = array
+        if (type is JSTupleType && type.sourceElement != null) {
+            val name = type.sourceElement!!.children.map { it.text }.getOrNull(index-1)
+            if (name != null) {
                         return mutableListOf(InlayInfo(name, psiElement.startOffset))
-                    } else {
-                        if (index == 1 && arrayName != null) {
-                            return mutableListOf(InlayInfo(arrayName, psiElement.startOffset))
-                        }
-                    }
-
+            } else {
+                if (index == 1 && arrayName != null) {
+                    return mutableListOf(InlayInfo(arrayName, psiElement.startOffset))
                 }
+            }
+
+            }
             }
         }
         return emptyList<InlayInfo>().toMutableList()

--- a/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
+++ b/src/main/kotlin/com/emberjs/hbs/HbsParameterNameHints.kt
@@ -50,7 +50,7 @@ class HbsParameterNameHints : InlayParameterHintsProvider {
                 file = followReferences(firstParam.children[0])
                 if (file == firstParam.children[0]) {
                     val id = PsiTreeUtil.collectElements(firstParam) { it !is LeafPsiElement && it.elementType == HbTokenTypes.ID }.lastOrNull()
-                    file = followReferences(id, psiElement.text)
+                    file = followReferences(id)
                 }
             }
 

--- a/src/main/kotlin/com/emberjs/utils/utils.kt
+++ b/src/main/kotlin/com/emberjs/utils/utils.kt
@@ -1,0 +1,139 @@
+package com.emberjs.utils
+
+import com.dmarcotte.handlebars.parsing.HbTokenTypes
+import com.emberjs.hbs.HbsModuleReference
+import com.intellij.lang.ecmascript6.psi.ES6ImportExportDeclaration
+import com.intellij.lang.ecmascript6.psi.JSClassExpression
+import com.intellij.lang.ecmascript6.resolve.ES6PsiUtil
+import com.intellij.lang.javascript.psi.*
+import com.intellij.lang.javascript.psi.ecma6.*
+import com.intellij.lang.javascript.psi.ecmal4.JSClass
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiReference
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.elementType
+import com.intellij.psi.util.parents
+
+fun resolveModifier(file: PsiFile): Array<JSFunction?> {
+    val func = resolveDefaultExport(file)
+    val installer: JSFunction? = PsiTreeUtil.collectElements(func) { it is JSFunction && it.name == "installModifier" }.firstOrNull() as JSFunction?
+    val updater: JSFunction? = PsiTreeUtil.collectElements(func, { it is JSFunction && it.name == "updateModifier"}).firstOrNull() as JSFunction?
+    val destroyer: JSFunction? = PsiTreeUtil.collectElements(func, { it is JSFunction && it.name == "destroyModifier"}).firstOrNull() as JSFunction?
+    return arrayOf(installer, updater, destroyer)
+}
+
+fun resolveDefaultExport(file: PsiFile): PsiElement? {
+    var exp = ES6PsiUtil.findDefaultExport(file)
+    val exportImport = PsiTreeUtil.findChildOfType(file, ES6ImportExportDeclaration::class.java)
+    if (exportImport != null && exportImport.children.find { it.text == "default" } != null) {
+        exp = ES6PsiUtil.resolveDefaultExport(exportImport).firstOrNull() as JSElement? ?: exp
+    }
+    var ref: Any? = exp?.children?.find { it is JSReferenceExpression } as JSReferenceExpression?
+    while (ref is JSReferenceExpression && ref.resolve() != null) {
+        ref = ref.resolve()
+    }
+    ref = ref as JSElement? ?: exp
+    val func = ref?.children?.find { it is JSCallExpression }
+    if (func != null) {
+        return func
+    }
+    val cls = ref?.children?.find { it is JSClassExpression }
+    if (cls != null) {
+        return cls
+    }
+    return ref as JSElement?
+}
+
+fun resolveHelper(file: PsiFile): JSFunction? {
+    val cls = resolveDefaultExport(file)
+    if (cls is JSCallExpression && cls.argumentList != null) {
+        var func: PsiElement? = cls.argumentList!!.arguments.last()
+        while (func is JSReferenceExpression) {
+            func = func.resolve()
+        }
+        if (func is JSFunction) {
+            return func
+        }
+    }
+    return null
+}
+
+
+
+fun findDefaultExportClass(file: PsiFile): JSClass? {
+    val exp = ES6PsiUtil.findDefaultExport(file)
+    var cls: Any? = exp?.children?.find { it is JSClass }
+    cls = cls ?: exp?.children?.find { it is JSFunction }
+    if (cls == null) {
+        val ref: JSReferenceExpression? = exp?.children?.find { it is JSReferenceExpression } as JSReferenceExpression?
+        cls = ref?.resolve()
+        if (cls is JSClass) {
+            return cls
+        }
+        cls = PsiTreeUtil.findChildOfType(ref?.resolve(), JSClass::class.java)
+        return cls
+    }
+    return cls as JSClass
+}
+
+
+fun findComponentArgsType(tsFile: PsiFile): TypeScriptObjectType? {
+    val cls = findDefaultExportClass(tsFile)
+    val type = PsiTreeUtil.findChildOfType(cls, TypeScriptSingleType::class.java)
+    var jsObject: TypeScriptObjectType? = null
+    if (type?.children?.getOrNull(0) is JSReferenceExpression) {
+        val res = (type.children[0] as PsiReference).resolve()
+        if (res is TypeScriptInterface) {
+            jsObject = res.body
+        }
+        if (res is TypeScriptTypeAlias) {
+            jsObject = res.children.find { it is TypeScriptObjectType } as TypeScriptObjectType
+        }
+        if (res is TypeScriptObjectType) {
+            jsObject = res
+        }
+    }
+    if (type?.children?.getOrNull(0) is TypeScriptObjectType) {
+        jsObject = type.children[0] as TypeScriptObjectType
+    }
+    return jsObject
+}
+
+
+fun resolveReference(reference: PsiReference?): PsiElement? {
+    var element = reference?.resolve()
+    if (element == null && reference is HbsModuleReference) {
+        element = reference.multiResolve(false).firstOrNull()?.element
+    }
+    return element
+}
+
+fun followReferences(element: PsiElement?): PsiElement? {
+
+    if (element?.reference != null) {
+        return followReferences(resolveReference(element.reference))
+    }
+    if (element?.references != null && element.references.isNotEmpty()) {
+        return followReferences(element.references.map { resolveReference(it) }.filterNotNull().firstOrNull())
+    }
+    return element
+}
+
+
+fun findFirstHbsParamFromParam(psiElement: PsiElement?): PsiElement? {
+    val parent = psiElement?.parents
+            ?.find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN_SEXPR }
+            ?:
+            psiElement?.parents
+                    ?.find { it.children.getOrNull(0)?.elementType == HbTokenTypes.OPEN }
+    if (parent == null) {
+        return null
+    }
+    // mustache name
+    val name = parent.children.getOrNull(1)
+    if (name?.references != null && name.references.isNotEmpty()) {
+        return name
+    }
+    return parent.children.getOrNull(1)?.children?.getOrNull(0)
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -50,6 +50,8 @@
         <fileBasedIndex implementation="com.emberjs.index.EmberNameIndex"/>
         <gotoClassContributor implementation="com.emberjs.navigation.EmberGotoClassContributor"/>
         <gotoRelatedProvider implementation="com.emberjs.navigation.EmberGotoRelatedProvider"/>
+        <codeInsight.parameterInfo language="Handlebars" implementationClass="com.emberjs.hbs.HbsParameterInfoHandler"/>
+        <codeInsight.parameterNameHints language="Handlebars" implementationClass="com.emberjs.hbs.HbsParameterNameHints"/>
         <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberInjectionAnnotator"/>
         <annotator language="ECMAScript 6" implementationClass="com.emberjs.psi.EmberRelationshipAnnotator"/>
 


### PR DESCRIPTION
depends on #345 
adds a name prefix to helpers and modifiers.
e.g. `did-insert fn: this.init, ...params: 1 2 3`. this will require a change on the modifiers/helpers to indicate the type either via typescript, jsdoc or destructuring

also shows the information when opening paramter info via ctrl+p.
will show information for a helper like `param1, param2, hashParam1= hashParam2=`
