### PR TITLE
Update IntelliJ to v2020.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-java@v1
         with:
-          java-version: '1.8'
+          java-version: '11'
 
       - uses: actions/cache@v1
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -5,10 +5,10 @@ buildscript {
 
         // see https://www.jetbrains.com/intellij-repository/releases/
         // and https://www.jetbrains.com/intellij-repository/snapshots/
-        intellijVersion = '2020.2.3'
+        intellijVersion = '2020.3'
 
         // see https://plugins.jetbrains.com/plugin/6884-handlebars-mustache/versions
-        handlebarsPluginVersion = '202.6397.21'
+        handlebarsPluginVersion = '203.5981.152'
     }
 
     repositories {


### PR DESCRIPTION
unfortunately our test are currently failing with:

```
com.emberjs.navigation.EmberGotoRelatedProviderTest > testCratesIo FAILED
    java.lang.AssertionError: ID with name 'ember.names' requested for plugin null but registered for com.emberjs
        at com.intellij.util.indexing.ID.findByName(ID.java:95)
        at com.intellij.util.indexing.ID.create(ID.java:68)
        at com.emberjs.index.EmberNameIndex.<clinit>(EmberNameIndex.kt:27)
        at com.emberjs.navigation.EmberGotoRelatedProviderTest.doTest(EmberGotoRelatedProviderTest.kt:124)
        at com.emberjs.navigation.EmberGotoRelatedProviderTest.testCratesIo(EmberGotoRelatedProviderTest.kt:15)

        Caused by:
        java.lang.Throwable
            at com.intellij.util.indexing.ID.<init>(ID.java:54)
            at com.intellij.util.indexing.ID.create(ID.java:69)
            at com.emberjs.index.EmberNameIndex.<clinit>(EmberNameIndex.kt:27)
            at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
            at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
            at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
            at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
            at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
            at com.intellij.serviceContainer.ComponentManagerImpl.instantiateClass(ComponentManagerImpl.kt:684)
            at com.intellij.openapi.extensions.impl.ExtensionComponentAdapter.instantiateClass(ExtensionComponentAdapter.java:51)
            at com.intellij.openapi.extensions.impl.XmlExtensionAdapter$SimpleConstructorInjectionAdapter.instantiateClass(XmlExtensionAdapter.java:133)
            at com.intellij.openapi.extensions.impl.ExtensionComponentAdapter.createInstance(ExtensionComponentAdapter.java:43)
            at com.intellij.openapi.extensions.impl.XmlExtensionAdapter.createInstance(XmlExtensionAdapter.java:69)
            at com.intellij.openapi.extensions.impl.ExtensionPointImpl.processAdapter(ExtensionPointImpl.java:472)
            at com.intellij.openapi.extensions.impl.ExtensionPointImpl.access$200(ExtensionPointImpl.java:37)
            at com.intellij.openapi.extensions.impl.ExtensionPointImpl$1.next(ExtensionPointImpl.java:367)
            at com.intellij.util.indexing.FileBasedIndexDataInitialization.initAssociatedDataForExtensions(FileBasedIndexDataInitialization.java:56)
            at com.intellij.util.indexing.FileBasedIndexDataInitialization.prepare(FileBasedIndexDataInitialization.java:92)
            at com.intellij.util.indexing.IndexInfrastructure$DataInitialization.call(IndexInfrastructure.java:122)
            at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
            at com.intellij.util.concurrency.BoundedTaskExecutor.doRun(BoundedTaskExecutor.java:216)
            at com.intellij.util.concurrency.BoundedTaskExecutor.access$200(BoundedTaskExecutor.java:27)
            at com.intellij.util.concurrency.BoundedTaskExecutor$1.execute(BoundedTaskExecutor.java:195)
            at com.intellij.util.ConcurrencyUtil.runUnderThreadName(ConcurrencyUtil.java:208)
            at com.intellij.util.concurrency.BoundedTaskExecutor$1.run(BoundedTaskExecutor.java:184)
            at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
            at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
            at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:668)
            at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:665)
            at java.base/java.security.AccessController.doPrivileged(AccessController.java:391)
            at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:665)
            at java.base/java.lang.Thread.run(Thread.java:832)
```