### PR TITLE
fix(configuration): remove deprecated usage of default getId implementation

### DIFF
--- a/src/main/kotlin/com/emberjs/configuration/serve/EmberServeConfigurationFactory.kt
+++ b/src/main/kotlin/com/emberjs/configuration/serve/EmberServeConfigurationFactory.kt
@@ -16,6 +16,10 @@ class EmberServeConfigurationFactory(type: ConfigurationType) : ConfigurationFac
         return FACTORY_NAME
     }
 
+    override fun getId(): String {
+        return "Ember Serve"
+    }
+
     companion object {
         private val FACTORY_NAME = "Ember serve configuration factory"
     }

--- a/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfigurationFactory.kt
+++ b/src/main/kotlin/com/emberjs/configuration/test/EmberTestConfigurationFactory.kt
@@ -12,7 +12,11 @@ class EmberTestConfigurationFactory(type: ConfigurationType) : ConfigurationFact
     }
 
     override fun getName(): String {
-        return FACTORY_NAME;
+        return FACTORY_NAME
+    }
+
+    override fun getId(): String {
+        return "Ember Test"
     }
 
     companion object {


### PR DESCRIPTION
I noticed that there was a deprecation exception being thrown when starting the plugin.

```
2020-12-21 20:24:46,466 [   6068]   WARN - util.DeprecatedMethodException - The default implementation of method 'com.intellij.execution.configurations.ConfigurationFactory.getId' is deprecated, you need to override it in 'class com.emberjs.configuration.test.EmberTestConfigurationFactory'. The default implementation delegates to 'getName' which may be localized but return value of this method must not depend on current localization. 
com.intellij.util.DeprecatedMethodException: The default implementation of method 'com.intellij.execution.configurations.ConfigurationFactory.getId' is deprecated, you need to override it in 'class com.emberjs.configuration.test.EmberTestConfigurationFactory'. The default implementation delegates to 'getName' which may be localized but return value of this method must not depend on current localization.
```

They want a custom implementation of `getId` for all run configuration.
See jetbrains fix in the official plugins:

https://github.com/JetBrains/intellij-plugins/commit/11287a111fd0d24175917c6cfbabc29663734da5