### PR TITLE
Gradle: Inline properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,5 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-fun properties(key: String) = project.findProperty(key).toString()
-
 plugins {
     // Java support
     id("java")
@@ -11,8 +9,8 @@ plugins {
     id("org.jetbrains.intellij") version "1.1.6"
 }
 
-group = properties("pluginGroup")
-version = properties("pluginVersion")
+group = "com.emberjs"
+version = "2021.2.1"
 
 // Configure project's dependencies
 repositories {
@@ -25,14 +23,21 @@ dependencies {
 // Configure gradle-intellij-plugin plugin.
 // Read more: https://github.com/JetBrains/gradle-intellij-plugin
 intellij {
-    pluginName.set(properties("pluginName"))
-    version.set(properties("platformVersion"))
-    type.set(properties("platformType"))
+    pluginName.set("Ember.js")
+
+    // see https://www.jetbrains.com/intellij-repository/releases/
+    // and https://www.jetbrains.com/intellij-repository/snapshots/
+    version.set("2021.2")
+    type.set("IU")
+
     downloadSources.set(!System.getenv().containsKey("CI"))
     updateSinceUntilBuild.set(true)
 
-    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
-    plugins.set(properties("platformPlugins").split(',').map(String::trim).filter(String::isNotEmpty))
+    // Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
+    // Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
+    //
+    // com.dmarcotte.handlebars: see https://plugins.jetbrains.com/plugin/6884-handlebars-mustache/versions
+    plugins.set(listOf("JavaScriptLanguage", "CSS", "yaml", "com.dmarcotte.handlebars:212.4746.2"))
 
     sandboxDir.set(project.rootDir.canonicalPath + "/.sandbox")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,21 +1,3 @@
-# IntelliJ Platform Artifacts Repositories
-# -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
-
-pluginGroup = com.emberjs
-pluginName = Ember.js
-pluginVersion = 2021.2.1
-
-platformType = IU
-# see https://www.jetbrains.com/intellij-repository/releases/
-# and https://www.jetbrains.com/intellij-repository/snapshots/
-platformVersion = 2021.2
-
-# Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
-# Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-#
-# com.dmarcotte.handlebars: see https://plugins.jetbrains.com/plugin/6884-handlebars-mustache/versions
-platformPlugins = JavaScriptLanguage, CSS, yaml, com.dmarcotte.handlebars:212.4746.2
-
 # Opt-out flag for bundling Kotlin standard library.
 # See https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library for details.
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
There does not seem to be any obvious reason for why these values should live in the properties file instead of directly in the build script