### PR TITLE
Add option to run `ember-template-lint --fix` on save

### DIFF
--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintActionOnSave.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintActionOnSave.kt
@@ -1,0 +1,31 @@
+import com.intellij.ide.actionsOnSave.impl.ActionsOnSaveFileDocumentManagerListener.ActionOnSave
+import com.intellij.lang.javascript.linter.eslint.standardjs.StandardJSConfiguration
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ProjectFileIndex
+
+class TemplateLintActionOnSave : ActionOnSave() {
+    override fun isEnabledForProject(project: Project): Boolean = isFixOnSaveEnabled(project)
+
+    override fun processDocuments(project: Project, documents: Array<out Document>) {
+        if (!this.isEnabledForProject(project)) return
+
+        val manager = FileDocumentManager.getInstance()
+        val fileIndex = ProjectFileIndex.getInstance(project)
+        val files = documents
+                .mapNotNull { manager.getFile(it) }
+                .filter { it.isInLocalFileSystem && fileIndex.isInContent(it) }
+                .toTypedArray()
+        if (files.isNotEmpty()) {
+            TemplateLintFixAction().processFiles(project, files, false, true)
+        }
+    }
+
+    companion object {
+        fun isFixOnSaveEnabled(project: Project): Boolean {
+            val config = TemplateLintConfiguration.getInstance(project)
+            return config.isEnabled && config.extendedState.state.isRunOnSave
+        }
+    }
+}

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintConfigurable.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintConfigurable.kt
@@ -1,7 +1,10 @@
 
+import com.intellij.ide.actionsOnSave.ActionOnSaveBackedByOwnConfigurable
+import com.intellij.ide.actionsOnSave.ActionOnSaveContext
 import com.intellij.lang.javascript.linter.JSLinterConfigurable
 import com.intellij.lang.javascript.linter.JSLinterView
 import com.intellij.openapi.project.Project
+import com.intellij.ui.components.ActionLink
 
 class TemplateLintConfigurable(project: Project, fullModeDialog: Boolean = false) :
         JSLinterConfigurable<TemplateLintState>(
@@ -25,4 +28,45 @@ class TemplateLintConfigurable(project: Project, fullModeDialog: Boolean = false
         return TemplateLintBundle.message("hbs.lint.configurable.name")
     }
 
+    override fun getView(): TemplateLintView? {
+        return super.getView() as TemplateLintView?
+    }
+
+    class TemplateLintOnSaveActionInfo(context: ActionOnSaveContext) :
+        ActionOnSaveBackedByOwnConfigurable<TemplateLintConfigurable>(
+            context, ID, TemplateLintConfigurable::class.java) {
+
+        override fun getActionOnSaveName(): String {
+            return TemplateLintBundle.message("hbs.lint.run.on.save.checkbox.on.actions.on.save.page")
+        }
+
+        override fun setActionOnSaveEnabled(configurable: TemplateLintConfigurable, enabled: Boolean) {
+            val view = configurable.view
+            if (view != null) {
+                view.myRunOnSaveCheckBox.isSelected = enabled
+            }
+        }
+
+        override fun isApplicableAccordingToStoredState(): Boolean {
+            return TemplateLintConfiguration.getInstance(this.project).isEnabled
+        }
+
+        override fun isApplicableAccordingToUiState(configurable: TemplateLintConfigurable): Boolean {
+            val checkbox = configurable.view?.myRunOnSaveCheckBox
+            return checkbox != null && checkbox.isVisible && checkbox.isEnabled
+        }
+
+        override fun isActionOnSaveEnabledAccordingToStoredState(): Boolean {
+            return TemplateLintActionOnSave.isFixOnSaveEnabled(this.project)
+        }
+
+        override fun isActionOnSaveEnabledAccordingToUiState(configurable: TemplateLintConfigurable): Boolean {
+            val checkbox = configurable.view?.myRunOnSaveCheckBox
+            return checkbox != null && checkbox.isVisible && checkbox.isEnabled && checkbox.isSelected
+        }
+
+        override fun getActionLinks(): MutableList<out ActionLink> {
+            return mutableListOf(createGoToPageInSettingsLink(ID))
+        }
+    }
 }

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintConfiguration.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintConfiguration.kt
@@ -5,25 +5,22 @@ import com.intellij.lang.javascript.linter.JSLinterInspection
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.JDOMExternalizerUtil
 import org.jdom.Element
-import kotlin.test.assertNotNull
 
 @State(name = "TemplateLintConfiguration", storages = [Storage("emberLinters/templatelint.xml")])
 class TemplateLintConfiguration(project: Project) : JSLinterConfiguration<TemplateLintState>(project) {
-    private val DEFAULT_STATE = TemplateLintState()
     private val myPackage: JSLinterPackage = JSLinterPackage(project, TemplateLintUtil.PACKAGE_NAME)
 
     override fun loadPrivateSettings(state: TemplateLintState): TemplateLintState {
         this.myPackage.readOrDetect()
         val constantPackage = myPackage.getPackage().constantPackage
+                ?: throw AssertionError("TemplateLint does not support non-constant node package refs")
 
-        assertNotNull(constantPackage, "TemplateLint does not support non-constant node package refs")
-
-        return TemplateLintState(this.myPackage.interpreter, constantPackage)
-    }
-
-    override fun fromXml(element: Element): TemplateLintState {
-        return this.defaultState
+        return state.copy(
+                myInterpreterRef = this.myPackage.interpreter,
+                myTemplateLintPackage = constantPackage
+        )
     }
 
     override fun savePrivateSettings(state: TemplateLintState) {
@@ -31,14 +28,30 @@ class TemplateLintConfiguration(project: Project) : JSLinterConfiguration<Templa
     }
 
     override fun toXml(state: TemplateLintState): Element? {
-        return null
+        if (state == defaultState) {
+            return null
+        }
+        val parent = Element(TemplateLintUtil.PACKAGE_NAME)
+        JDOMExternalizerUtil.writeField(parent, TAG_RUN_ON_SAVE, state.isRunOnSave.toString(), false.toString())
+        return parent
+    }
+
+    override fun fromXml(element: Element): TemplateLintState {
+        val isRunOnSave = JDOMExternalizerUtil.readField(element, TAG_RUN_ON_SAVE, false.toString()).toBoolean()
+        return this.defaultState.copy(isRunOnSave = isRunOnSave)
     }
 
     override fun getDefaultState(): TemplateLintState {
-        return DEFAULT_STATE
+        return TemplateLintState.DEFAULT
     }
 
     override fun getInspectionClass(): Class<out JSLinterInspection> {
         return TemplateLintInspection::class.java
+    }
+
+    companion object {
+        private const val TAG_RUN_ON_SAVE = "fix-on-save"
+
+        fun getInstance(project: Project) = getInstance(project, TemplateLintConfiguration::class.java)
     }
 }

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintEnabler.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintEnabler.kt
@@ -1,6 +1,5 @@
 import com.intellij.javascript.nodejs.PackageJsonData
 import com.intellij.lang.javascript.JSBundle
-import com.intellij.lang.javascript.linter.JSLinterConfiguration.getInstance
 import com.intellij.lang.javascript.linter.JSLinterGuesser
 import com.intellij.lang.javascript.linter.JSLinterUtil
 import com.intellij.notification.Notification
@@ -55,7 +54,7 @@ class TemplateLintEnabler : DirectoryProjectConfigurator {
         }
 
         fun templateLintEnabled(project: Project, enabled: Boolean) {
-            getInstance(project, TemplateLintConfiguration::class.java).isEnabled = enabled
+            TemplateLintConfiguration.getInstance(project).isEnabled = enabled
         }
 
         fun notifyEnabled(project: Project, dependency: String) {

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintExternalAnnotator.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintExternalAnnotator.kt
@@ -27,7 +27,7 @@ class TemplateLintExternalAnnotator(onTheFly: Boolean = true) : JSLinterExternal
     }
 
     override fun annotate(input: JSLinterInput<TemplateLintState>): JSLinterAnnotationResult? {
-        return TemplateLintExternalRunner(this.isOnTheFly).execute(input)
+        return TemplateLintExternalRunner(this.isOnTheFly).highlight(input)
     }
 
     override fun apply(file: PsiFile, annotationResult: JSLinterAnnotationResult?, holder: AnnotationHolder) {

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintFixAction.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintFixAction.kt
@@ -1,0 +1,62 @@
+import com.dmarcotte.handlebars.file.HbFileType
+import com.emberjs.icons.EmberIcons
+import com.intellij.lang.javascript.linter.JSLinterFixAction
+import com.intellij.lang.javascript.linter.JSLinterInput
+import com.intellij.openapi.application.ReadAction
+import com.intellij.openapi.fileTypes.FileTypeRegistry
+import com.intellij.openapi.progress.ProgressIndicator
+import com.intellij.openapi.progress.Task
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
+
+class TemplateLintFixAction : JSLinterFixAction(
+        { TemplateLintBundle.message("hbs.lint.configurable.name") },
+        { TemplateLintBundle.message("hbs.lint.action.fix.problems.description") },
+        EmberIcons.ICON_16
+) {
+    override fun getConfiguration(project: Project) = TemplateLintConfiguration.getInstance(project)
+
+    override fun createTask(project: Project, filesToProcess: MutableCollection<out VirtualFile>, completeCallback: Runnable, modalProgress: Boolean): Task {
+        return makeModalOrBackgroundTask(project, modalProgress) { indicator ->
+            filesToProcess.forEach { file ->
+                indicator.checkCanceled()
+                val psiFile = ReadAction.compute<PsiFile?, RuntimeException> {
+                    PsiManager.getInstance(project).findFile(file)
+                }
+                if (psiFile != null) {
+                    fixFile(psiFile)
+                }
+            }
+
+            completeCallback.run()
+        }
+    }
+
+    private fun makeModalOrBackgroundTask(project: Project, modalProgress: Boolean, body: (ProgressIndicator) -> Unit): Task {
+        val title = TemplateLintBundle.message("hbs.lint.action.modal.title")
+        return if (modalProgress) {
+            object : Task.Modal(project, title, true) {
+                override fun run(indicator: ProgressIndicator) {
+                    body(indicator)
+                }
+            }
+        } else {
+            object : Task.Backgroundable(project, title, true) {
+                override fun run(indicator: ProgressIndicator) {
+                    body(indicator)
+                }
+            }
+        }
+    }
+
+    override fun isFileAccepted(project: Project, file: VirtualFile): Boolean {
+        return FileTypeRegistry.getInstance().isFileOfType(file, HbFileType.INSTANCE)
+    }
+
+    private fun fixFile(psiFile: PsiFile) {
+        val input = JSLinterInput.create(psiFile, TemplateLintConfiguration.getInstance(psiFile.project).extendedState.state, null)
+        TemplateLintExternalRunner().fixFile(input)
+    }
+}

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintOnSaveInfoProvider.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintOnSaveInfoProvider.kt
@@ -1,0 +1,10 @@
+import com.intellij.ide.actionsOnSave.ActionOnSaveContext
+import com.intellij.ide.actionsOnSave.ActionOnSaveInfo
+import com.intellij.ide.actionsOnSave.ActionOnSaveInfoProvider
+import com.intellij.lang.javascript.linter.eslint.EslintConfigurable
+
+class TemplateLintOnSaveInfoProvider : ActionOnSaveInfoProvider() {
+    override fun getActionOnSaveInfos(context: ActionOnSaveContext): MutableCollection<out ActionOnSaveInfo> {
+        return mutableListOf(TemplateLintConfigurable.TemplateLintOnSaveActionInfo(context))
+    }
+}

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintResultParser.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintResultParser.kt
@@ -19,7 +19,7 @@ class TemplateLintResultParser {
         private const val SEVERITY = "severity"
         private const val MESSAGE = "message"
 
-        private fun parseItem(map: JSONObject): JSLinterError? {
+        private fun parseItem(map: JSONObject): JSLinterError {
             val line = map.getInt(LINE)
             val column = map.getInt(COLUMN)
             val rule = map.getString(RULE)
@@ -36,12 +36,12 @@ class TemplateLintResultParser {
     }
 
     @Throws(Exception::class)
-    fun parse(stdout: String?): List<JSLinterError?>? {
+    fun parse(stdout: String?): List<JSLinterError>? {
         if (StringUtil.isEmptyOrSpaces(stdout)) {
             return null
         }
 
-        val errorList: ArrayList<JSLinterError?> = ArrayList()
+        val errorList: ArrayList<JSLinterError> = ArrayList()
         try {
             val obj = JSONObject(stdout)
 

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintSessionData.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintSessionData.kt
@@ -6,6 +6,7 @@ class TemplateLintSessionData(
         val templateLintPackage: TemplateLintPackage,
         val workingDir: VirtualFile,
         val fileToLint: VirtualFile,
-        val fileToLintContent: String
+        val fileToLintContent: String,
+        val fix: Boolean,
 ) {
 }

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintState.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintState.kt
@@ -3,25 +3,20 @@ import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterRef
 import com.intellij.javascript.nodejs.util.NodePackage
 import com.intellij.javascript.nodejs.util.NodePackageRef
 import com.intellij.lang.javascript.linter.JSNpmLinterState
-import kotlin.test.assertNotNull
 
-class TemplateLintState(
+data class TemplateLintState(
         private val myInterpreterRef: NodeJsInterpreterRef,
         private val myTemplateLintPackage: NodePackage,
-        private val myPackageRef: NodePackageRef = NodePackageRef.create(myTemplateLintPackage)
+        val isRunOnSave: Boolean,
 ) : JSNpmLinterState<TemplateLintState> {
 
-    constructor() : this(
-            NodeJsInterpreterRef.createProjectRef(),
-            NodePackage("")
-    )
+    private val myPackageRef: NodePackageRef = NodePackageRef.create(myTemplateLintPackage)
 
     override fun withLinterPackage(packageRef: NodePackageRef): TemplateLintState {
         val constantPackage = packageRef.constantPackage
+                ?: throw AssertionError(this.javaClass.simpleName + " does not support non-constant package refs")
 
-        assertNotNull(constantPackage != null, this.javaClass.simpleName + " does not support non-constant package refs")
-
-        return TemplateLintState(this.myInterpreterRef, constantPackage!!)
+        return copy(myTemplateLintPackage = constantPackage)
     }
 
     override fun getInterpreterRef(): NodeJsInterpreterRef {
@@ -33,11 +28,18 @@ class TemplateLintState(
     }
 
     override fun withInterpreterRef(interpreterRef: NodeJsInterpreterRef): TemplateLintState {
-        return TemplateLintState(interpreterRef, this.myTemplateLintPackage)
+        return copy(myInterpreterRef = interpreterRef)
     }
 
     val templateLintPackage: NodePackage
         get() {
             return this.myTemplateLintPackage
         }
+
+    companion object {
+        val DEFAULT = TemplateLintState(
+                NodeJsInterpreterRef.createProjectRef(),
+                NodePackage(""),
+                false)
+    }
 }

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintView.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintView.kt
@@ -1,4 +1,5 @@
 
+import com.intellij.ide.actionsOnSave.ActionsOnSaveConfigurable
 import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreterField
 import com.intellij.javascript.nodejs.util.NodePackageField
 import com.intellij.lang.javascript.linter.JSLinterBaseView
@@ -7,11 +8,13 @@ import com.intellij.util.ui.FormBuilder
 import com.intellij.util.ui.SwingHelper
 import java.awt.Component
 import javax.swing.BorderFactory
+import javax.swing.JCheckBox
 import javax.swing.JPanel
 
 class TemplateLintView(project: Project, fullModeDialog: Boolean) : JSLinterBaseView<TemplateLintState>(fullModeDialog) {
     private val myNodeInterpreterField: NodeJsInterpreterField = NodeJsInterpreterField(project, false)
     private val myTemplateLintPackageField: NodePackageField = NodePackageField(myNodeInterpreterField, TemplateLintUtil.PACKAGE_NAME)
+    val myRunOnSaveCheckBox: JCheckBox = JCheckBox(TemplateLintBundle.message("hbs.lint.run.on.save"))
 
     private val panel = FormBuilder.createFormBuilder()
             .setHorizontalGap(10)
@@ -19,6 +22,8 @@ class TemplateLintView(project: Project, fullModeDialog: Boolean) : JSLinterBase
             .setFormLeftIndent(10)
             .addLabeledComponent(TemplateLintBundle.message("hbs.lint.node.path.label"), myNodeInterpreterField)
             .addLabeledComponent(TemplateLintBundle.message("hbs.lint.package.label"), this.myTemplateLintPackageField)
+            .addComponent(myRunOnSaveCheckBox)
+            .addComponent(ActionsOnSaveConfigurable.createGoToActionsOnSavePageLink())
             .panel
 
     private val myCenterPanel: JPanel = SwingHelper.wrapWithHorizontalStretch(panel).apply {
@@ -26,12 +31,16 @@ class TemplateLintView(project: Project, fullModeDialog: Boolean) : JSLinterBase
     }
 
     override fun getState(): TemplateLintState {
-        return TemplateLintState(myNodeInterpreterField.interpreterRef, myTemplateLintPackageField.selected)
+        return TemplateLintState(
+                myNodeInterpreterField.interpreterRef,
+                myTemplateLintPackageField.selected,
+                myRunOnSaveCheckBox.isEnabled && myRunOnSaveCheckBox.isSelected)
     }
 
     override fun setState(state: TemplateLintState) {
         myNodeInterpreterField.interpreterRef = state.interpreterRef
         myTemplateLintPackageField.selected = state.templateLintPackage
+        myRunOnSaveCheckBox.isSelected = state.isRunOnSave;
         if (isFullModeDialog) {
             myNodeInterpreterField.setPreferredWidthToFitText()
             myTemplateLintPackageField.setPreferredWidthToFitText()

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/config/TemplateLintConfigFileChangeTracker.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/config/TemplateLintConfigFileChangeTracker.kt
@@ -7,7 +7,7 @@ import com.intellij.openapi.vfs.VirtualFile
 
 class TemplateLintConfigFileChangeTracker(project: Project) : JSLinterConfigChangeTracker(project, ::isTemplateLintConfigFile) {
     override fun isAnalyzerRestartNeeded(project: Project, file: VirtualFile): Boolean {
-        return JSLinterConfiguration.getInstance(project, TemplateLintConfiguration::class.java).extendedState.isEnabled
+        return TemplateLintConfiguration.getInstance(project).extendedState.isEnabled
     }
 
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -99,6 +99,12 @@
         <projectService serviceImplementation="TemplateLintConfiguration"/>
         <projectService serviceImplementation="TemplateLintConfigFileChangeTracker"/>
         <projectService serviceImplementation="TemplateLintUnsavedConfigFileManager"/>
+        <actionOnSaveInfoProvider id="TemplateLintOnSaveInfoProvider"
+                                  implementation="TemplateLintOnSaveInfoProvider"
+                                  order="after FormatOnSaveInfoProvider, before PrettierOnSaveInfoProvider, before BuildOnSaveInfoProvider, before FileWatcherOnSaveInfoProvider, before UploadOnSaveInfoProvider"/>
+        <actionOnSave id="TemplateLintActionOnSave"
+                      implementation="TemplateLintActionOnSave"
+                      order="after FormatOnSaveAction, before PrettierActionOnSave"/>
         <lang.substitutor language="JavaScript" implementationClass="TemplateLintConfigLangSubstitutor"/>
         <fileType name="JavaScript" fileNames=".template-lintrc.js"/>
     </extensions>
@@ -110,6 +116,11 @@
     <actions>
         <action id="GenerateEmberCode" class="com.emberjs.actions.EmberGenerateCodeAction">
             <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFromTemplate"/>
+        </action>
+
+        <action id="TemplateLintFix" class="TemplateLintFixAction">
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
         </action>
     </actions>
 

--- a/src/main/resources/com/emberjs/locale/TemplateLintBundle.properties
+++ b/src/main/resources/com/emberjs/locale/TemplateLintBundle.properties
@@ -4,5 +4,9 @@ hbs.lint.package.label=&TemplateLint package:
 hbs.lint.node.path.label=&Node interpreter:
 hbs.lint.inspection=TemplateLint
 hbs.lint.configurable.title=Handlebars
+hbs.lint.run.on.save=R&un ember-template-lint --fix on save
+hbs.lint.run.on.save.checkbox.on.actions.on.save.page=Run ember-template-lint --fix
+hbs.lint.action.modal.title=TemplateLint Fix
+hbs.lint.action.fix.problems.description=Fix TemplateLint problems by calling 'ember-template-lint --fix'
 
 hbs.inspections.code.quality.tools.group=Code quality tools


### PR DESCRIPTION
<img width="548" alt="Screen Shot 2021-11-09 at 7 47 23 PM" src="https://user-images.githubusercontent.com/752885/141047990-85bd8ff6-c85e-4045-a2d3-cd478a61de3e.png">

<img width="719" alt="Screen Shot 2021-11-09 at 7 47 41 PM" src="https://user-images.githubusercontent.com/752885/141048001-13b8a3d4-39fa-470a-b1a1-41ebb39a64df.png">

Also adds it as a regular action when right-clicking hbs files:

<img width="362" alt="Screen Shot 2021-11-09 at 7 47 52 PM" src="https://user-images.githubusercontent.com/752885/141047977-6fdf6404-4ede-4050-8515-0699073732c0.png">
