### PR TITLE
support ember-template-lint v4 command-line syntax

### DIFF
--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintExternalRunner.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintExternalRunner.kt
@@ -110,7 +110,8 @@ class TemplateLintExternalRunner(private val myIsOnTheFly: Boolean = false) {
             sessionData.templateLintPackage
                     .addMainEntryJsFile(commandLine, sessionData.interpreter)
 
-            commandLine.addParameter("--json")
+            val useFormatArg = sessionData.templateLintPackage.version?.isGreaterOrEqualThan(4, 0, 0) ?: false
+            commandLine.addParameter(if (useFormatArg) "--format=json" else "--json")
 
             val pathToLint = FileUtil.toSystemDependentName(sessionData.fileToLint.path)
             val relativePath = FileUtil.getRelativePath(workDirectory.absolutePath, pathToLint, File.separatorChar)

--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintPackage.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintPackage.kt
@@ -5,6 +5,7 @@ import com.intellij.javascript.nodejs.interpreter.NodeJsInterpreter
 import com.intellij.javascript.nodejs.library.yarn.YarnPnpNodePackage
 import com.intellij.javascript.nodejs.util.NodePackage
 import com.intellij.openapi.project.Project
+import com.intellij.util.text.SemVer
 import java.io.File
 import java.io.IOException
 
@@ -12,11 +13,11 @@ class TemplateLintPackage(
         private val myProject: Project,
         private val myPkg: NodePackage
 ) {
+    val version: SemVer?
+        get() = myPkg.getVersion(myProject)
+
     val versionStr: String
-        get() {
-            val version = myPkg.getVersion(myProject)
-            return version?.rawVersion ?: "<unknown>"
-        }
+        get() = version?.rawVersion ?: "<unknown>"
 
     @Throws(ExecutionException::class)
     fun addMainEntryJsFile(commandLine: GeneralCommandLine, interpreter: NodeJsInterpreter) {


### PR DESCRIPTION
Use `--format=json` for version 4+. Continue using `--json` for older versions.

* version 3.1.0 (2021-03) adds `--format=json`
     https://github.com/ember-template-lint/ember-template-lint/pull/1340
* version 3.3.0 (2021-04) deprecates `--json` 
    https://github.com/ember-template-lint/ember-template-lint/pull/1907
* version 4.0.0 (2022-01) removes `--json`
    https://github.com/ember-template-lint/ember-template-lint/pull/2193

Fixes #428