### PR TITLE
Fix deadlock running TemplateLint on save

### DIFF
--- a/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintFixAction.kt
+++ b/src/main/kotlin/com/emberjs/hbs/linter/ember-template-lint/TemplateLintFixAction.kt
@@ -2,6 +2,7 @@ import com.dmarcotte.handlebars.file.HbFileType
 import com.emberjs.icons.EmberIcons
 import com.intellij.lang.javascript.linter.JSLinterFixAction
 import com.intellij.lang.javascript.linter.JSLinterInput
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.application.ReadAction
 import com.intellij.openapi.fileTypes.FileTypeRegistry
 import com.intellij.openapi.progress.ProgressIndicator
@@ -29,8 +30,7 @@ class TemplateLintFixAction : JSLinterFixAction(
                     fixFile(psiFile)
                 }
             }
-
-            completeCallback.run()
+            ApplicationManager.getApplication().invokeLater(completeCallback)
         }
     }
 


### PR DESCRIPTION
Fixes #484

Most linters read the file contents from stdin and write the fixed file contents to stdout. Their IntelliJ implementations disable the automatic refresh (`JSLinterFixAction#needRefreshFilesAfter` returns false) and so they won't hit this deadlock. TemplateLint writes its fixes directly to the same file so we need to refresh the files after.